### PR TITLE
feat: usdt market

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+**/public/sw.js
+**/public/workbox-*.js

--- a/src/app/(main)/components/MarketLinks/index.tsx
+++ b/src/app/(main)/components/MarketLinks/index.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { useRecoilValue } from 'recoil';
+import { cn } from '@/lib/utils';
+import { typeState } from '@/store/coin';
+
+export default function MarketLinks() {
+  const coinType = useRecoilValue(typeState);
+
+  return (
+    <>
+      {coinType !== 'BTC' && (
+        <div
+          className={cn(
+            'flex items-center text-center mb-0.5',
+            'max-md:text-xs',
+            'max-sm:text-[10px]',
+          )}
+        >
+          <Link
+            className={cn(
+              'py-0.5 px-2  text-[#d0d0d0]',
+              coinType === 'KRW' && 'text-[#f8b64c] ',
+            )}
+            href="/?type=KRW"
+          >
+            바이낸스 - BTC 마켓
+          </Link>
+          <Link
+            className={cn(
+              'p-0.5  text-[#d0d0d0]',
+              coinType === 'USDT' && 'text-[#f8b64c]',
+            )}
+            href="/?type=USDT"
+          >
+            바이낸스 - USDT 마켓
+          </Link>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/(main)/components/Page.tsx
+++ b/src/app/(main)/components/Page.tsx
@@ -7,10 +7,11 @@ import { useCoinList, useTickersData } from '@/hooks';
 import { cn } from '@/lib/utils';
 
 const HomePage = () => {
-  const { krwCoinData, btcCoinData } = useCoinList();
+  const { krwCoinData, btcCoinData, usdtCoinData } = useCoinList();
   const { data, handleSort } = useTickersData({
     krwCoinData,
     btcCoinData,
+    usdtCoinData,
   });
 
   return (
@@ -19,7 +20,12 @@ const HomePage = () => {
         <Suspense>
           <Tab tabs={['KRW', 'BTC']} />
         </Suspense>
-        <div className={cn('max-md:text-xs max-sm:text-[10px]')}>
+        <div
+          className={cn(
+            'max-md:text-xs max-sm:text-[10px]',
+            'flex items-center justify-between',
+          )}
+        >
           <p className={cn('m-2 max-md:m-1')}>
             암호화폐 - {data?.length ?? 0}개
           </p>

--- a/src/app/(main)/components/Page.tsx
+++ b/src/app/(main)/components/Page.tsx
@@ -5,6 +5,7 @@ import CoinTable from '@/components/CoinTable';
 import Tab from '@/components/Tab';
 import { useCoinList, useTickersData } from '@/hooks';
 import { cn } from '@/lib/utils';
+import MarketLinks from './MarketLinks';
 
 const HomePage = () => {
   const { krwCoinData, btcCoinData, usdtCoinData } = useCoinList();
@@ -23,12 +24,13 @@ const HomePage = () => {
         <div
           className={cn(
             'max-md:text-xs max-sm:text-[10px]',
-            'flex items-center justify-between',
+            'flex items-center justify-between my-0.5',
           )}
         >
           <p className={cn('m-2 max-md:m-1')}>
             암호화폐 - {data?.length ?? 0}개
           </p>
+          <MarketLinks />
         </div>
         <CoinTable coinList={data ?? []} handleSort={handleSort} />
       </div>

--- a/src/components/CoinTable.tsx
+++ b/src/components/CoinTable.tsx
@@ -6,6 +6,7 @@ import { useRecoilValue } from 'recoil';
 import { faStar as UnLiked } from '@fortawesome/free-regular-svg-icons';
 import { faStar as Liked } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { MARKET_SYMBOLS, TABLE_HEADERS } from 'constant';
 import Button from '@/components/Button';
 import { Flex } from '@/components/Flex';
 import Spacing from '@/components/Spacing';
@@ -19,8 +20,7 @@ import { cn, getBreakpointQuery, removeDuplicate, setComma } from '@/lib/utils';
 import { typeState } from '@/store/coin';
 import { breakpoints } from '@/styles/mixin';
 import { palette } from '@/styles/variables';
-
-const TABLE_HEADER = ['코인', '업비트(₩)', '바이낸스', '차이(%)'];
+import { TickerType } from '@/types/Coin';
 
 type Props = {
   coinList: CombinedTickers[];
@@ -96,10 +96,18 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
     <Table
       header={
         <>
-          {TABLE_HEADER.map((name, idx) => (
+          {TABLE_HEADERS.map((name, idx) => (
             <Table.Header
               key={name}
-              name={name}
+              name={
+                idx > 0 && idx < 3
+                  ? `${name}(${
+                      MARKET_SYMBOLS[idx === 1 ? 'upbit' : 'binance'][
+                        coinType as TickerType
+                      ]
+                    })`
+                  : name
+              }
               right={
                 <Image src="/assets/updown.png" alt="" width={6} height={12} />
               }

--- a/src/components/CoinTable.tsx
+++ b/src/components/CoinTable.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMedia } from 'react-use';
 import { useRecoilValue } from 'recoil';
@@ -94,147 +93,120 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
   }, [coinList, isFavSymbol]);
 
   return (
-    <>
-      {coinType !== 'BTC' && (
-        <div
-          className={cn(
-            'flex text-center bg-white mb-0.5',
-            'max-md:text-xs',
-            'max-sm:text-[10px]',
-          )}
-        >
-          <Link className={cn('p-1 flex-1 border-b-2')} href="/?type=KRW">
-            바이낸스 - BTC 마켓
-          </Link>
-          <Link className={cn('p-1 flex-1 border-b-2')} href="/?type=USDT">
-            바이낸스 - USDT 마켓
-          </Link>
-        </div>
-      )}
-
-      <Table
-        header={
+    <Table
+      header={
+        <>
+          {TABLE_HEADER.map((name, idx) => (
+            <Table.Header
+              key={name}
+              name={name}
+              right={
+                <Image src="/assets/updown.png" alt="" width={6} height={12} />
+              }
+              width="25%"
+              onClick={handleSort(sortColumn[idx])}
+            />
+          ))}
+        </>
+      }
+      body={
+        !filteredCointList.length ? (
+          <Table.Skeleton />
+        ) : (
           <>
-            {TABLE_HEADER.map((name, idx) => (
-              <Table.Header
-                key={name}
-                name={name}
-                right={
-                  <Image
-                    src="/assets/updown.png"
-                    alt=""
-                    width={6}
-                    height={12}
-                  />
-                }
-                width="25%"
-                onClick={handleSort(sortColumn[idx])}
-              />
+            {filteredCointList.map((data) => (
+              <Table.Row key={data.symbol}>
+                <Table.Cell>
+                  <div
+                    className={cn('flex items-center gap-2', 'max-sm:gap-0.5')}
+                  >
+                    <Flex
+                      className="cursor-pointer"
+                      alignItems="center"
+                      gap="4px"
+                      onClick={() =>
+                        navigate.push(
+                          `/exchange?code=${
+                            data.symbol
+                          }&type=${coinType.toUpperCase()}`,
+                        )
+                      }
+                    >
+                      <picture>
+                        <img
+                          className="w-5 min-w-4 rounded-[2rem] max-sm:w-4"
+                          alt={data.symbol}
+                          src={getCoinSymbolImage(data.symbol)}
+                          width={20}
+                          height={20}
+                        />
+                      </picture>
+                      <Text fontSize={isSmDown ? 14 : 16}>{data.symbol}</Text>
+                    </Flex>
+                    <Spacing size="4px" />
+                    <Button
+                      padding={{
+                        top: '0',
+                        bottom: '0',
+                        left: '0',
+                        right: '0',
+                      }}
+                      onClick={toggleFav(data.symbol)}
+                    >
+                      <FontAwesomeIcon
+                        className="text-[#e2be1b]"
+                        icon={isFavSymbol(data.symbol) ? Liked : UnLiked}
+                      />
+                    </Button>
+                  </div>
+                </Table.Cell>
+                <Table.Cell>
+                  <div className={cn('flex flex-col gap-0.5')}>
+                    <p className="m-0">
+                      {coinType !== 'BTC'
+                        ? `${setComma(data.last)}₩`
+                        : data.last}
+                    </p>
+                    {data.upbitWarning && (
+                      <div
+                        className={cn(
+                          'text-white bg-orange-300',
+                          'p-0.5 text-sm font-semibold',
+                          'max-md:text-[10px]',
+                        )}
+                      >
+                        투자 유의
+                      </div>
+                    )}
+                  </div>
+                </Table.Cell>
+                <Table.Cell>
+                  <div className={cn('flex flex-col')}>
+                    <p className="m-0">{data.blast}</p>
+                    {data.convertedBlast && (
+                      <p>{setComma(data.convertedBlast ?? 0)}₩</p>
+                    )}
+                  </div>
+                </Table.Cell>
+                <Table.Cell
+                  color={
+                    data.per
+                      ? data.per > 0
+                        ? palette.red
+                        : palette.blue
+                      : palette.black
+                  }
+                >
+                  <div className={cn('flex flex-col')}>
+                    <p className="m-0">{setComma(data?.per ?? 0)}%</p>
+                  </div>
+                </Table.Cell>
+              </Table.Row>
             ))}
           </>
-        }
-        body={
-          !filteredCointList.length ? (
-            <Table.Skeleton />
-          ) : (
-            <>
-              {filteredCointList.map((data) => (
-                <Table.Row key={data.symbol}>
-                  <Table.Cell>
-                    <div
-                      className={cn(
-                        'flex items-center gap-2',
-                        'max-sm:gap-0.5',
-                      )}
-                    >
-                      <Flex
-                        className="cursor-pointer"
-                        alignItems="center"
-                        gap="4px"
-                        onClick={() =>
-                          navigate.push(
-                            `/exchange?code=${
-                              data.symbol
-                            }&type=${coinType.toUpperCase()}`,
-                          )
-                        }
-                      >
-                        <picture>
-                          <img
-                            className="w-5 min-w-4 rounded-[2rem] max-sm:w-4"
-                            alt={data.symbol}
-                            src={getCoinSymbolImage(data.symbol)}
-                            width={20}
-                            height={20}
-                          />
-                        </picture>
-                        <Text fontSize={isSmDown ? 14 : 16}>{data.symbol}</Text>
-                      </Flex>
-                      <Spacing size="4px" />
-                      <Button
-                        padding={{
-                          top: '0',
-                          bottom: '0',
-                          left: '0',
-                          right: '0',
-                        }}
-                        onClick={toggleFav(data.symbol)}
-                      >
-                        <FontAwesomeIcon
-                          className="text-[#e2be1b]"
-                          icon={isFavSymbol(data.symbol) ? Liked : UnLiked}
-                        />
-                      </Button>
-                    </div>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <div className={cn('flex flex-col gap-0.5')}>
-                      <p className="m-0">
-                        {coinType !== 'BTC'
-                          ? `${setComma(data.last)}₩`
-                          : data.last}
-                      </p>
-                      {data.upbitWarning && (
-                        <div
-                          className={cn(
-                            'text-white bg-orange-300',
-                            'p-0.5 text-sm font-semibold',
-                            'max-md:text-[10px]',
-                          )}
-                        >
-                          투자 유의
-                        </div>
-                      )}
-                    </div>
-                  </Table.Cell>
-                  <Table.Cell>
-                    <div className={cn('flex flex-col')}>
-                      <p className="m-0">{data.blast}</p>
-                      {data.convertedBlast && (
-                        <p>{setComma(data.convertedBlast ?? 0)}₩</p>
-                      )}
-                    </div>
-                  </Table.Cell>
-                  <Table.Cell
-                    color={
-                      data.per
-                        ? data.per > 0
-                          ? palette.red
-                          : palette.blue
-                        : palette.black
-                    }
-                  >
-                    <div className={cn('flex flex-col')}>
-                      <p className="m-0">{setComma(data?.per ?? 0)}%</p>
-                    </div>
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </>
-          )
-        }
-      />
-    </>
+        )
+      }
+    />
   );
 };
 

--- a/src/components/CoinTable.tsx
+++ b/src/components/CoinTable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { useMedia } from 'react-use';
 import { useRecoilValue } from 'recoil';
 import { faStar as UnLiked } from '@fortawesome/free-regular-svg-icons';
@@ -8,7 +8,6 @@ import { faStar as Liked } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MARKET_SYMBOLS, TABLE_HEADERS } from 'constant';
 import Button from '@/components/Button';
-import { Flex } from '@/components/Flex';
 import Spacing from '@/components/Spacing';
 import Table from '@/components/Table';
 import Text from '@/components/Text';
@@ -30,7 +29,6 @@ type Props = {
 const CoinTable = ({ coinList, handleSort }: Props) => {
   const coinType = useRecoilValue(typeState);
   const isSmDown = useMedia(getBreakpointQuery(breakpoints.down('sm')), false);
-  const navigate = useRouter();
 
   const { value: krwFavList, updateValue: updateKrwFavList } = useLocalStorage({
     key: 'krwfav',
@@ -128,17 +126,9 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
                   <div
                     className={cn('flex items-center gap-2', 'max-sm:gap-0.5')}
                   >
-                    <Flex
-                      className="cursor-pointer"
-                      alignItems="center"
-                      gap="4px"
-                      onClick={() =>
-                        navigate.push(
-                          `/exchange?code=${
-                            data.symbol
-                          }&type=${coinType.toUpperCase()}`,
-                        )
-                      }
+                    <Link
+                      className={cn('flex items-center gap-1 cursor-pointer')}
+                      href={`/exchange?code=${data.symbol}&type=KRW`}
                     >
                       <picture>
                         <img
@@ -150,7 +140,7 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
                         />
                       </picture>
                       <Text fontSize={isSmDown ? 14 : 16}>{data.symbol}</Text>
-                    </Flex>
+                    </Link>
                     <Spacing size="4px" />
                     <Button
                       padding={{

--- a/src/components/CoinTable.tsx
+++ b/src/components/CoinTable.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMedia } from 'react-use';
 import { useRecoilValue } from 'recoil';
@@ -20,7 +21,7 @@ import { typeState } from '@/store/coin';
 import { breakpoints } from '@/styles/mixin';
 import { palette } from '@/styles/variables';
 
-const TABLE_HEADER = ['코인', '업비트(₩)', '바이낸스(BTC)', '차이(%)'];
+const TABLE_HEADER = ['코인', '업비트(₩)', '바이낸스', '차이(%)'];
 
 type Props = {
   coinList: CombinedTickers[];
@@ -93,120 +94,147 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
   }, [coinList, isFavSymbol]);
 
   return (
-    <Table
-      header={
-        <>
-          {TABLE_HEADER.map((name, idx) => (
-            <Table.Header
-              key={name}
-              name={name}
-              right={
-                <Image src="/assets/updown.png" alt="" width={6} height={12} />
-              }
-              width="25%"
-              onClick={handleSort(sortColumn[idx])}
-            />
-          ))}
-        </>
-      }
-      body={
-        !filteredCointList.length ? (
-          <Table.Skeleton />
-        ) : (
+    <>
+      {coinType !== 'BTC' && (
+        <div
+          className={cn(
+            'flex text-center bg-white mb-0.5',
+            'max-md:text-xs',
+            'max-sm:text-[10px]',
+          )}
+        >
+          <Link className={cn('p-1 flex-1 border-b-2')} href="/?type=KRW">
+            바이낸스 - BTC 마켓
+          </Link>
+          <Link className={cn('p-1 flex-1 border-b-2')} href="/?type=USDT">
+            바이낸스 - USDT 마켓
+          </Link>
+        </div>
+      )}
+
+      <Table
+        header={
           <>
-            {filteredCointList.map((data) => (
-              <Table.Row key={data.symbol}>
-                <Table.Cell>
-                  <div
-                    className={cn('flex items-center gap-2', 'max-sm:gap-0.5')}
-                  >
-                    <Flex
-                      className="cursor-pointer"
-                      alignItems="center"
-                      gap="4px"
-                      onClick={() =>
-                        navigate.push(
-                          `/exchange?code=${
-                            data.symbol
-                          }&type=${coinType.toUpperCase()}`,
-                        )
-                      }
-                    >
-                      <picture>
-                        <img
-                          className="w-5 min-w-4 rounded-[2rem] max-sm:w-4"
-                          alt={data.symbol}
-                          src={getCoinSymbolImage(data.symbol)}
-                          width={20}
-                          height={20}
-                        />
-                      </picture>
-                      <Text fontSize={isSmDown ? 14 : 16}>{data.symbol}</Text>
-                    </Flex>
-                    <Spacing size="4px" />
-                    <Button
-                      padding={{
-                        top: '0',
-                        bottom: '0',
-                        left: '0',
-                        right: '0',
-                      }}
-                      onClick={toggleFav(data.symbol)}
-                    >
-                      <FontAwesomeIcon
-                        className="text-[#e2be1b]"
-                        icon={isFavSymbol(data.symbol) ? Liked : UnLiked}
-                      />
-                    </Button>
-                  </div>
-                </Table.Cell>
-                <Table.Cell>
-                  <div className={cn('flex flex-col gap-0.5')}>
-                    <p className="m-0">
-                      {coinType === 'KRW'
-                        ? `${setComma(data.last)}₩`
-                        : data.last}
-                    </p>
-                    {data.upbitWarning && (
-                      <div
-                        className={cn(
-                          'text-white bg-orange-300',
-                          'p-0.5 text-sm font-semibold',
-                          'max-md:text-[10px]',
-                        )}
-                      >
-                        투자 유의
-                      </div>
-                    )}
-                  </div>
-                </Table.Cell>
-                <Table.Cell>
-                  <div className={cn('flex flex-col')}>
-                    <p className="m-0">{data.blast}</p>
-                    {data.convertedBlast && (
-                      <p>{setComma(data.convertedBlast ?? 0)}₩</p>
-                    )}
-                  </div>
-                </Table.Cell>
-                <Table.Cell
-                  color={
-                    data.per
-                      ? data.per > 0
-                        ? palette.red
-                        : palette.blue
-                      : palette.black
-                  }
-                >
-                  <div className={cn('flex flex-col')}>
-                    <p className="m-0">{setComma(data?.per ?? 0)}%</p>
-                  </div>
-                </Table.Cell>
-              </Table.Row>
+            {TABLE_HEADER.map((name, idx) => (
+              <Table.Header
+                key={name}
+                name={name}
+                right={
+                  <Image
+                    src="/assets/updown.png"
+                    alt=""
+                    width={6}
+                    height={12}
+                  />
+                }
+                width="25%"
+                onClick={handleSort(sortColumn[idx])}
+              />
             ))}
           </>
-        )
-      }
-    />
+        }
+        body={
+          !filteredCointList.length ? (
+            <Table.Skeleton />
+          ) : (
+            <>
+              {filteredCointList.map((data) => (
+                <Table.Row key={data.symbol}>
+                  <Table.Cell>
+                    <div
+                      className={cn(
+                        'flex items-center gap-2',
+                        'max-sm:gap-0.5',
+                      )}
+                    >
+                      <Flex
+                        className="cursor-pointer"
+                        alignItems="center"
+                        gap="4px"
+                        onClick={() =>
+                          navigate.push(
+                            `/exchange?code=${
+                              data.symbol
+                            }&type=${coinType.toUpperCase()}`,
+                          )
+                        }
+                      >
+                        <picture>
+                          <img
+                            className="w-5 min-w-4 rounded-[2rem] max-sm:w-4"
+                            alt={data.symbol}
+                            src={getCoinSymbolImage(data.symbol)}
+                            width={20}
+                            height={20}
+                          />
+                        </picture>
+                        <Text fontSize={isSmDown ? 14 : 16}>{data.symbol}</Text>
+                      </Flex>
+                      <Spacing size="4px" />
+                      <Button
+                        padding={{
+                          top: '0',
+                          bottom: '0',
+                          left: '0',
+                          right: '0',
+                        }}
+                        onClick={toggleFav(data.symbol)}
+                      >
+                        <FontAwesomeIcon
+                          className="text-[#e2be1b]"
+                          icon={isFavSymbol(data.symbol) ? Liked : UnLiked}
+                        />
+                      </Button>
+                    </div>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <div className={cn('flex flex-col gap-0.5')}>
+                      <p className="m-0">
+                        {coinType !== 'BTC'
+                          ? `${setComma(data.last)}₩`
+                          : data.last}
+                      </p>
+                      {data.upbitWarning && (
+                        <div
+                          className={cn(
+                            'text-white bg-orange-300',
+                            'p-0.5 text-sm font-semibold',
+                            'max-md:text-[10px]',
+                          )}
+                        >
+                          투자 유의
+                        </div>
+                      )}
+                    </div>
+                  </Table.Cell>
+                  <Table.Cell>
+                    <div className={cn('flex flex-col')}>
+                      <p className="m-0">{data.blast}</p>
+                      {data.convertedBlast && (
+                        <p>{setComma(data.convertedBlast ?? 0)}₩</p>
+                      )}
+                    </div>
+                  </Table.Cell>
+                  <Table.Cell
+                    color={
+                      data.per
+                        ? data.per > 0
+                          ? palette.red
+                          : palette.blue
+                        : palette.black
+                    }
+                  >
+                    <div className={cn('flex flex-col')}>
+                      <p className="m-0">{setComma(data?.per ?? 0)}%</p>
+                    </div>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </>
+          )
+        }
+      />
+    </>
   );
 };
 

--- a/src/components/Initialize/Client.tsx
+++ b/src/components/Initialize/Client.tsx
@@ -8,22 +8,27 @@ import type { Coin } from '@/types/Coin';
 type InitializeProps = {
   btc: Coin[];
   krw: Coin[];
+  usdt: Coin[];
 };
 
-function InitializeClient({ btc, krw }: InitializeProps) {
+function InitializeClient({ btc, krw, usdt }: InitializeProps) {
   const { data } = useQuery({
     queryKey: ['coin-list'],
     queryFn: async () => {
       const krwData = await getCoins('KRW');
       const btcData = await getCoins('BTC');
+      const usdtData = await getCoins('USDT');
+
       return {
         btc: btcData,
         krw: krwData,
+        usdt: usdtData,
       };
     },
     placeholderData: {
       btc,
       krw,
+      usdt,
     },
   });
 
@@ -31,6 +36,7 @@ function InitializeClient({ btc, krw }: InitializeProps) {
     initialData: {
       krw: data?.krw ?? krw,
       btc: data?.btc ?? btc,
+      usdt: data?.usdt ?? usdt,
     },
     workerEnabled: false,
   });

--- a/src/components/Initialize/index.tsx
+++ b/src/components/Initialize/index.tsx
@@ -4,8 +4,9 @@ import InitializeClient from './Client';
 async function fetchData() {
   const krwData = await getCoinsV2('KRW');
   const btcData = await getCoinsV2('BTC');
+  const usdtData = await getCoinsV2('USDT');
 
-  return { krw: krwData, btc: btcData };
+  return { krw: krwData, btc: btcData, usdt: usdtData };
 }
 
 async function Initialize() {

--- a/src/components/NavigationEvents.tsx
+++ b/src/components/NavigationEvents.tsx
@@ -17,6 +17,10 @@ export function NavigationEvents() {
       setType('BTC');
     }
 
+    if (url.includes('type=USDT')) {
+      setType('USDT');
+    }
+
     if (!url || url === '/' || url.includes('?type=KRW')) {
       setType('KRW');
     }

--- a/src/components/Worker.tsx
+++ b/src/components/Worker.tsx
@@ -8,6 +8,7 @@ const Worker = () => {
     initialData: {
       krw: [],
       btc: [],
+      usdt: [],
     },
   });
   return null;

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -1,0 +1,14 @@
+export const TABLE_HEADERS = ['코인', '업비트', '바이낸스', '차이(%)'];
+
+export const MARKET_SYMBOLS = {
+  binance: {
+    BTC: 'BTC',
+    KRW: 'BTC',
+    USDT: 'USDT',
+  },
+  upbit: {
+    BTC: 'BTC',
+    KRW: '₩',
+    USDT: '₩',
+  },
+};

--- a/src/hooks/queries/useCoinList.ts
+++ b/src/hooks/queries/useCoinList.ts
@@ -1,12 +1,18 @@
 'use client';
 
 import { useRecoilValue } from 'recoil';
-import { btcCoinListState, krCoinListState } from '@/store/coin';
+import {
+  btcCoinListState,
+  krCoinListState,
+  usdtCoinListState,
+} from '@/store/coin';
 
 const useCoinList = () => {
   const krwCoinData = useRecoilValue(krCoinListState);
   const btcCoinData = useRecoilValue(btcCoinListState);
-  return { krwCoinData, btcCoinData };
+  const usdtCoinData = useRecoilValue(usdtCoinListState);
+
+  return { krwCoinData, btcCoinData, usdtCoinData };
 };
 
 export default useCoinList;

--- a/src/hooks/queries/useInitCoinList.ts
+++ b/src/hooks/queries/useInitCoinList.ts
@@ -4,12 +4,16 @@ import { useEffect, useRef } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { initSocket } from '@/lib/socket';
 import { getLocalStorageData, setLocalStorageData } from '@/lib/storage';
-import { btcCoinListState, krCoinListState } from '@/store/coin';
+import {
+  btcCoinListState,
+  krCoinListState,
+  usdtCoinListState,
+} from '@/store/coin';
 import { Coin } from '@/types/Coin';
 
 type UseInitCointListProps = {
   workerEnabled?: boolean;
-  initialData: Record<'krw' | 'btc', Coin[]>;
+  initialData: Record<'krw' | 'btc' | 'usdt', Coin[]>;
 };
 
 const useInitCoinList = ({
@@ -19,6 +23,7 @@ const useInitCoinList = ({
   const workerRef = useRef<Worker | null>(null);
   const setKrwCoinList = useSetRecoilState(krCoinListState);
   const setBtcCoinList = useSetRecoilState(btcCoinListState);
+  const setUsdtCoinList = useSetRecoilState(usdtCoinListState);
 
   useEffect(() => {
     if (
@@ -29,15 +34,23 @@ const useInitCoinList = ({
       return;
     }
 
-    const { krw, btc } = initialData;
+    const { krw, btc, usdt } = initialData;
 
     setKrwCoinList({
       isLoading: false,
       data: krw,
     });
     setBtcCoinList({ isLoading: false, data: btc });
-    initSocket([...krw, ...btc]);
-  }, [workerEnabled, initialData, setBtcCoinList, setKrwCoinList]);
+    setUsdtCoinList({ isLoading: false, data: usdt });
+
+    initSocket([...krw, ...btc, ...usdt]);
+  }, [
+    workerEnabled,
+    initialData,
+    setBtcCoinList,
+    setKrwCoinList,
+    setUsdtCoinList,
+  ]);
 
   useEffect(() => {
     if (!workerEnabled) return;
@@ -45,12 +58,13 @@ const useInitCoinList = ({
     const localData = getLocalStorageData('coins');
 
     if (localData) {
-      const { krw, btc } = localData;
+      const { krw, btc, usdt } = localData;
       setKrwCoinList({
         isLoading: false,
         data: krw,
       });
       setBtcCoinList({ isLoading: false, data: btc });
+      setUsdtCoinList({ isLoading: false, data: usdt });
     }
 
     workerRef.current = new Worker(
@@ -83,7 +97,7 @@ const useInitCoinList = ({
     return () => {
       workerRef.current?.terminate();
     };
-  }, [workerEnabled, setBtcCoinList, setKrwCoinList]);
+  }, [workerEnabled, setBtcCoinList, setKrwCoinList, setUsdtCoinList]);
 };
 
 export default useInitCoinList;

--- a/src/lib/coin.ts
+++ b/src/lib/coin.ts
@@ -6,7 +6,7 @@ import {
 } from '@/api';
 import type { Coin, UpbitCoin } from '@/types/Coin';
 
-type Currency = 'KRW' | 'BTC';
+type Currency = 'KRW' | 'BTC' | 'USDT';
 
 export const getCoinSymbolImage = (symbol: string) =>
   `https://static.upbit.com/logos/${symbol}.png`;
@@ -34,9 +34,35 @@ export const getCoinsV2 = async (type: Currency) => {
         (data: any) => data.symbol.endsWith('BTC') && data.status === 'TRADING',
       )
       .map((data: any) => data.symbol.slice(0, data.symbol.length - 3));
+    const binanceUsdtCoins = binanceData?.symbols
+      ?.filter(
+        (data: any) =>
+          data.symbol.endsWith('USDT') && data.status === 'TRADING',
+      )
+      .map((data: any) => data.symbol.slice(0, data.symbol.length - 4))
+      .slice(1);
 
     // filtered data
-    const data: Coin[] = binanceBtcCoins
+    const dataWithUSDT: Coin[] = binanceUsdtCoins
+      .filter(
+        (symbol: string) =>
+          upbitKrwCoins.findIndex(
+            ({ market }: any) => market === `KRW-${symbol}`,
+          ) !== -1,
+      )
+      .map((symbol: string) => {
+        const data = {
+          name: symbol,
+          USDT:
+            upbitKrwCoins.findIndex(
+              ({ market }: any) => market === `KRW-${symbol}`,
+            ) !== -1,
+        };
+        return data;
+      })
+      .sort((data1: Coin, data2: Coin) => (data1.name > data2.name ? 1 : -1));
+
+    const dataWithBTC: Coin[] = binanceBtcCoins
       .filter(
         (symbol: string) =>
           upbitKrwCoins.findIndex(
@@ -62,7 +88,9 @@ export const getCoinsV2 = async (type: Currency) => {
       })
       .sort((data1: Coin, data2: Coin) => (data1.name > data2.name ? 1 : -1));
 
-    return data.filter((data: Coin) => data[type as Currency]);
+    return type === 'USDT'
+      ? dataWithUSDT.filter((data: Coin) => data.USDT)
+      : dataWithBTC.filter((data: Coin) => data[type as Currency]);
   } catch (err) {
     console.error(err);
     return [];
@@ -92,9 +120,35 @@ export const getCoins = async (type: Currency) => {
         (data: any) => data.symbol.endsWith('BTC') && data.status === 'TRADING',
       )
       .map((data: any) => data.symbol.slice(0, data.symbol.length - 3));
+    const binanceUsdtCoins = binanceData?.symbols
+      ?.filter(
+        (data: any) =>
+          data.symbol.endsWith('USDT') && data.status === 'TRADING',
+      )
+      .map((data: any) => data.symbol.slice(0, data.symbol.length - 4))
+      .slice(1);
 
     // filtered data
-    const data: Coin[] = binanceBtcCoins
+    const dataWithUSDT: Coin[] = binanceUsdtCoins
+      .filter(
+        (symbol: string) =>
+          upbitKrwCoins.findIndex(
+            ({ market }: any) => market === `KRW-${symbol}`,
+          ) !== -1,
+      )
+      .map((symbol: string) => {
+        const data = {
+          name: symbol,
+          USDT:
+            upbitKrwCoins.findIndex(
+              ({ market }: any) => market === `KRW-${symbol}`,
+            ) !== -1,
+        };
+        return data;
+      })
+      .sort((data1: Coin, data2: Coin) => (data1.name > data2.name ? 1 : -1));
+
+    const dataWithBTC: Coin[] = binanceBtcCoins
       .filter(
         (symbol: string) =>
           upbitKrwCoins.findIndex(
@@ -120,7 +174,9 @@ export const getCoins = async (type: Currency) => {
       })
       .sort((data1: Coin, data2: Coin) => (data1.name > data2.name ? 1 : -1));
 
-    return data.filter((data: Coin) => data[type as Currency]);
+    return type === 'USDT'
+      ? dataWithUSDT.filter((data: Coin) => data.USDT)
+      : dataWithBTC.filter((data: Coin) => data[type as Currency]);
   } catch (err) {
     console.error(err);
     return [];

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -278,7 +278,7 @@ export const combineTickers = (
             tickers.binance.btc[name] == undefined
               ? 0
               : parseFloat(
-                  (tickers.binance.btc[name].tradePrice * btcKRw).toFixed(2),
+                  (tickers.binance.btc[name].tradePrice * btcKRw).toFixed(7),
                 ),
           per:
             tickers.upbit.krw[name] == undefined ||
@@ -309,12 +309,12 @@ export const combineTickers = (
           blast:
             tickers.binance.usdt[name]?.tradePrice == undefined
               ? 0
-              : parseFloat(tickers.binance.usdt[name].tradePrice.toFixed(4)),
+              : parseFloat(tickers.binance.usdt[name].tradePrice.toFixed(7)),
           convertedBlast:
             tickers.binance.usdt[name]?.tradePrice == undefined
               ? 0
               : parseFloat(
-                  (tickers.binance.usdt[name].tradePrice * usdToKrw).toFixed(2),
+                  (tickers.binance.usdt[name].tradePrice * usdToKrw).toFixed(7),
                 ),
           per:
             tickers.upbit.usdt[name] == undefined ||
@@ -324,7 +324,7 @@ export const combineTickers = (
                   tickers.upbit.krw[name].tradePrice,
                   parseFloat(
                     (tickers.binance.usdt[name].tradePrice * usdToKrw).toFixed(
-                      2,
+                      4,
                     ),
                   ),
                 ),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,7 +15,7 @@ export function cn(...inputs: ClassValue[]) {
  * @param y  숫자
  */
 export const getPercent = (x: number, y: number) => {
-  return ((x - y) / y) * 100;
+  return (x / y - 1) * 100;
 };
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,7 +15,7 @@ export function cn(...inputs: ClassValue[]) {
  * @param y  숫자
  */
 export const getPercent = (x: number, y: number) => {
-  return (x / y - 1) * 100;
+  return ((x - y) / y) * 100;
 };
 
 /**

--- a/src/store/coin.ts
+++ b/src/store/coin.ts
@@ -30,6 +30,14 @@ export const btcCoinListState = atom<CoinState>({
   },
 });
 
+export const usdtCoinListState = atom<CoinState>({
+  key: `usdtCoinListState/${generateUid()}`,
+  default: {
+    isLoading: true,
+    data: [],
+  },
+});
+
 export const watchListState = atom<WatchListState>({
   key: `watchListState/${generateUid()}`,
   default: {

--- a/src/types/Coin.ts
+++ b/src/types/Coin.ts
@@ -2,6 +2,7 @@ export type Coin = {
   name: string;
   KRW: boolean;
   BTC: boolean;
+  USDT: boolean;
   img?: string;
   upbit?: boolean;
   binance?: boolean;
@@ -14,7 +15,7 @@ export type UpbitCoin = {
   english_name: string;
 };
 
-export type TickerType = 'KRW' | 'BTC';
+export type TickerType = 'KRW' | 'BTC' | 'USDT';
 
 type MarketData = {
   market_cap: string;

--- a/src/types/Ticker.ts
+++ b/src/types/Ticker.ts
@@ -3,6 +3,7 @@ export type Exchange = Record<
   {
     krw: Ticker;
     btc: Ticker;
+    usdt: Ticker;
   }
 >;
 


### PR DESCRIPTION
주요 진행 작업:
- 바이낸스 USDT 가격 기준 김프 및 가격 노출
- 비교 기준 분류를 위한 [바이낸스 - BTC 마켓], [바이낸스 - USDT 마켓] 탭 추가 

기타:
- usdtCoinListState store 추가
- 상수 데이터 관리용 constant 추가

![image](https://github.com/user-attachments/assets/78a424b5-492b-4cb0-9f32-3fc450083f65)
