### PR TITLE
feat: replace recoil -> zustand

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.0",
     "react-use": "^17.5.0",
-    "recoil": "^0.7.7",
     "socket.io": "^4.7.5",
     "tailwind-merge": "^2.3.0",
     "zustand": "^5.0.4"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-use": "^17.5.0",
     "recoil": "^0.7.7",
     "socket.io": "^4.7.5",
-    "tailwind-merge": "^2.3.0"
+    "tailwind-merge": "^2.3.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       react-use:
         specifier: ^17.5.0
         version: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      recoil:
-        specifier: ^0.7.7
-        version: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       socket.io:
         specifier: ^4.7.5
         version: 4.8.1
@@ -9677,6 +9674,7 @@ snapshots:
       recoil: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       socket.io: 4.8.1
       tailwind-merge: 2.6.0
+      zustand: 5.0.4(@types/react@18.3.20)(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@emotion/is-prop-valid'
@@ -9688,9 +9686,11 @@ snapshots:
       - bufferutil
       - debug
       - encoding
+      - immer
       - react-native
       - sass
       - supports-color
+      - use-sync-external-store
       - utf-8-validate
 
   collect-v8-coverage@1.0.2: {}
@@ -12257,9 +12257,11 @@ snapshots:
       - bufferutil
       - debug
       - encoding
+      - immer
       - react-native
       - sass
       - supports-color
+      - use-sync-external-store
       - utf-8-validate
 
   p-limit@2.3.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       tailwind-merge:
         specifier: ^2.3.0
         version: 2.6.0
+      zustand:
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@18.3.20)(react@18.3.1)
     devDependencies:
       '@svgr/webpack':
         specifier: ^8.1.0
@@ -6173,6 +6176,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.4:
+    resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -13799,3 +13820,8 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.4(@types/react@18.3.20)(react@18.3.1):
+    optionalDependencies:
+      '@types/react': 18.3.20
+      react: 18.3.1

--- a/src/app/(main)/components/ExchangeList/index.tsx
+++ b/src/app/(main)/components/ExchangeList/index.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useRecoilValue } from 'recoil';
 import Exchange from '@/components/Exchange';
 import { exchangeHeader } from '@/data/table';
 import { cn, setComma } from '@/lib/utils';
-import { exchangeSelector } from '@/store/exchange';
+import { useExchangeStore } from '@/store/exchange';
 
 function ExchangeList() {
-  const exchangeData = useRecoilValue(exchangeSelector);
+  const exchangeData = useExchangeStore();
+
   return (
     <section className="max-md:overflow-auto">
       <div

--- a/src/app/(main)/components/MarketLinks/index.tsx
+++ b/src/app/(main)/components/MarketLinks/index.tsx
@@ -5,14 +5,13 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { Dropdown } from 'ownui-system';
 import { DropdownSelectedItem } from 'ownui-system/dist/components/Dropdown/dropdown';
-import { useRecoilValue } from 'recoil';
 import { MARKET_INFO } from 'constant';
 import { useIsomorphicLayoutEffect } from 'hooks/common';
 import { cn } from '@/lib/utils';
-import { typeState } from '@/store/coin';
+import { useCoinStore } from '@/store/coin';
 
 export default function MarketLinks() {
-  const coinType = useRecoilValue(typeState);
+  const { type } = useCoinStore();
   const navigate = useRouter();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -35,16 +34,16 @@ export default function MarketLinks() {
   }
 
   useIsomorphicLayoutEffect(() => {
-    if (coinType) {
+    if (type) {
       setSelectedItem(
-        MARKET_INFO.find((item) => item.value === coinType) ?? MARKET_INFO[0],
+        MARKET_INFO.find((item) => item.value === type) ?? MARKET_INFO[0],
       );
     }
-  }, [coinType]);
+  }, [type]);
 
   return (
     <>
-      {coinType !== 'BTC' && selectedItem && (
+      {type !== 'BTC' && selectedItem && (
         <div className="max-md:mr-1">
           <Dropdown
             isOpen={isOpen}

--- a/src/app/exchange/components/Page.tsx
+++ b/src/app/exchange/components/Page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState, useId } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useMedia } from 'react-use';
-import { useRecoilValue } from 'recoil';
 import CoinInfo from '@/components/CoinInfo';
 import { Divider } from '@/components/Divider';
 import ExchangeChart from '@/components/ExchangeChart';
@@ -18,7 +17,7 @@ import { exchangeTabs, timeTabs } from '@/data/tab';
 import { useExchangeData } from '@/hooks';
 import { getCoins, getCoinSymbolImage } from '@/lib/coin';
 import { cn, formatPrice, getBreakpointQuery, setComma } from '@/lib/utils';
-import { cryptoSocketState } from '@/store/socket';
+import { useCryptoSocketStore } from '@/store/socket';
 import { breakpoints } from '@/styles/mixin';
 import { palette } from '@/styles/variables';
 import type { CandleType } from '@/types/Candle';
@@ -40,7 +39,7 @@ const ExchangePage = ({ code, type }: ExchangePageProps) => {
     value: 'upbit',
     index: 0,
   });
-  const { btcKrw } = useRecoilValue(cryptoSocketState);
+  const { btcKrw } = useCryptoSocketStore();
 
   const priceSymbol = type === 'KRW' ? 'KRW' : 'BTC';
   const exchangeRate =

--- a/src/components/CoinTable.tsx
+++ b/src/components/CoinTable.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react';
 import Link from 'next/link';
 import { Icon } from 'ownui-system';
 import { useMedia } from 'react-use';
-import { useRecoilValue } from 'recoil';
 import { faStar as UnLiked } from '@fortawesome/free-regular-svg-icons';
 import { faStar as Liked } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -15,7 +14,7 @@ import { useLocalStorage } from '@/hooks';
 import { getCoinSymbolImage } from '@/lib/coin';
 import { sortColumn } from '@/lib/sort';
 import { cn, getBreakpointQuery, removeDuplicate, setComma } from '@/lib/utils';
-import { typeState } from '@/store/coin';
+import { useCoinStore } from '@/store/coin';
 import { CombinedTickers } from '@/store/socket';
 import { breakpoints } from '@/styles/mixin';
 import { palette } from '@/styles/variables';
@@ -27,7 +26,7 @@ type Props = {
 };
 
 const CoinTable = ({ coinList, handleSort }: Props) => {
-  const coinType = useRecoilValue(typeState);
+  const { type } = useCoinStore();
   const isSmDown = useMedia(getBreakpointQuery(breakpoints.down('sm')), false);
 
   const { value: krwFavList, updateValue: updateKrwFavList } = useLocalStorage({
@@ -41,11 +40,11 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
 
   const isFavSymbol = useCallback(
     (symbol: string) => {
-      return coinType !== 'BTC'
+      return type !== 'BTC'
         ? krwFavList.includes(symbol)
         : btcFavList.includes(symbol);
     },
-    [btcFavList, coinType, krwFavList],
+    [btcFavList, type, krwFavList],
   );
 
   const toggleFav = (symbol: string) => () => {
@@ -58,7 +57,7 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
   };
 
   const handleFav = (symbol: string) => {
-    if (coinType !== 'BTC') {
+    if (type !== 'BTC') {
       updateKrwFavList(removeDuplicate([...krwFavList, symbol]));
       return;
     }
@@ -67,7 +66,7 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
   };
 
   const handleUnFav = (symbol: string) => {
-    if (coinType !== 'BTC') {
+    if (type !== 'BTC') {
       updateKrwFavList(
         krwFavList.filter((coinSymbol: string) => symbol !== coinSymbol),
       );
@@ -101,7 +100,7 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
                 idx > 0 && idx < 3
                   ? `${name}(${
                       MARKET_SYMBOLS[idx === 1 ? 'upbit' : 'binance'][
-                        coinType as TickerType
+                        type as TickerType
                       ]
                     })`
                   : name
@@ -155,7 +154,7 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
                 <Table.Cell>
                   <div className={cn('flex flex-col gap-0.5')}>
                     <p className="m-0">
-                      {coinType !== 'BTC'
+                      {type !== 'BTC'
                         ? `${setComma(data.last, 6)}₩`
                         : data.last}
                     </p>

--- a/src/components/ExchangeChart.tsx
+++ b/src/components/ExchangeChart.tsx
@@ -4,14 +4,13 @@ import { useMemo, useRef, useState } from 'react';
 import { Chart, init, dispose, Nullable } from 'klinecharts';
 import { useMounted } from 'ownui-system';
 import { useMedia } from 'react-use';
-import { useRecoilValue } from 'recoil';
 import {
   useBinanceCandles,
   useUpbitCandles,
   useIsomorphicLayoutEffect,
 } from '@/hooks';
 import { getBreakpointQuery, reCalculateTimeStamp } from '@/lib/utils';
-import { cryptoSocketState } from '@/store/socket';
+import { useCryptoSocketStore } from '@/store/socket';
 import { breakpoints } from '@/styles/mixin';
 import { palette } from '@/styles/variables';
 import type { CandleType } from '@/types/Candle';
@@ -39,7 +38,7 @@ const ExchangeChart = ({
   const isMounted = useMounted();
   const [isInitialized, setIsInitialized] = useState(false);
   const isSmDown = useMedia(getBreakpointQuery(breakpoints.down('sm')), false);
-  const { btcKrw } = useRecoilValue(cryptoSocketState);
+  const { btcKrw } = useCryptoSocketStore();
 
   const exchangeRate =
     priceSymbol === 'BTC' || exchange === 'upbit' ? 1 : btcKrw.upbit;

--- a/src/components/NavigationEvents.tsx
+++ b/src/components/NavigationEvents.tsx
@@ -2,28 +2,27 @@
 
 import { useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { useSetRecoilState } from 'recoil';
-import { typeState } from '@/store/coin';
+import { useCoinStore } from '@/store/coin';
 
 export function NavigationEvents() {
   const searchParams = useSearchParams();
-  const setType = useSetRecoilState(typeState);
+  const { updateType } = useCoinStore();
 
   useEffect(() => {
     const type = searchParams?.get('type');
 
     if (type === 'BTC') {
-      setType('BTC');
+      updateType('BTC');
     }
 
     if (type === 'USDT') {
-      setType('USDT');
+      updateType('USDT');
     }
 
     if (!type || type === 'KRW') {
-      setType('KRW');
+      updateType('KRW');
     }
-  }, [searchParams, setType]);
+  }, [searchParams, updateType]);
 
   return null;
 }

--- a/src/components/Providers/SharedWorkerProvider.tsx
+++ b/src/components/Providers/SharedWorkerProvider.tsx
@@ -3,13 +3,12 @@
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useMounted } from 'ownui-system';
-import { useSetRecoilState } from 'recoil';
-import { cryptoSocketState } from '@/store/socket';
+import { useCryptoSocketStore } from '@/store/socket';
 
 export default function SharedWorkerProvider({ children }: PropsWithChildren) {
   const isMounted = useMounted();
   const [sharedWorker, setSharedWorker] = useState<SharedWorker | null>(null);
-  const setCryptoStateData = useSetRecoilState(cryptoSocketState);
+  const { setSocketState } = useCryptoSocketStore();
 
   useQuery({
     queryKey: ['crypto-ws'],
@@ -37,7 +36,7 @@ export default function SharedWorkerProvider({ children }: PropsWithChildren) {
       if (type === 'tickers') {
         const { upbit, binance } = payload;
 
-        setCryptoStateData({
+        setSocketState({
           tickers: {
             upbit: upbit.data,
             binance: binance.data,
@@ -65,7 +64,7 @@ export default function SharedWorkerProvider({ children }: PropsWithChildren) {
         type: 'disconnect',
       });
     };
-  }, [isMounted, setCryptoStateData]);
+  }, [isMounted, setSocketState]);
 
   return <>{children}</>;
 }

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -2,18 +2,15 @@
 
 import { PropsWithChildren, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { RecoilRoot } from 'recoil';
 import SharedWorkerProvider from './SharedWorkerProvider';
 
 function Providers({ children }: PropsWithChildren) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <SharedWorkerProvider>{children}</SharedWorkerProvider>
-      </QueryClientProvider>
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <SharedWorkerProvider>{children}</SharedWorkerProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/src/hooks/queries/useCoinList.ts
+++ b/src/hooks/queries/useCoinList.ts
@@ -1,16 +1,13 @@
 'use client';
 
-import { useRecoilValue } from 'recoil';
-import {
-  btcCoinListState,
-  krCoinListState,
-  usdtCoinListState,
-} from '@/store/coin';
+import { useCoinStore } from '@/store/coin';
 
 const useCoinList = () => {
-  const krwCoinData = useRecoilValue(krCoinListState);
-  const btcCoinData = useRecoilValue(btcCoinListState);
-  const usdtCoinData = useRecoilValue(usdtCoinListState);
+  const {
+    krwList: krwCoinData,
+    btcList: btcCoinData,
+    usdtList: usdtCoinData,
+  } = useCoinStore();
 
   return { krwCoinData, btcCoinData, usdtCoinData };
 };

--- a/src/hooks/queries/useExchangeData.ts
+++ b/src/hooks/queries/useExchangeData.ts
@@ -1,8 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { useRecoilValue } from 'recoil';
-import { cryptoSocketState } from '@/store/socket';
+import { useCryptoSocketStore } from '@/store/socket';
 import type { Exchange } from '@/types/Ticker';
 
 type UseExchangeDataProps = {
@@ -18,7 +17,7 @@ const useExchangeData = ({
   exchange,
   exchangeRate,
 }: UseExchangeDataProps) => {
-  const { tickers } = useRecoilValue(cryptoSocketState);
+  const { tickers } = useCryptoSocketStore();
 
   return useQuery({
     queryKey: ['exchange', code, type, exchange],

--- a/src/hooks/queries/useInitCoinList.ts
+++ b/src/hooks/queries/useInitCoinList.ts
@@ -1,12 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
-import {
-  btcCoinListState,
-  krCoinListState,
-  usdtCoinListState,
-} from '@/store/coin';
+import { useCoinStore } from '@/store/coin';
 import { Coin } from '@/types/Coin';
 
 type UseInitCointListProps = {
@@ -14,24 +9,25 @@ type UseInitCointListProps = {
 };
 
 const useInitCoinList = ({ initialData }: UseInitCointListProps) => {
-  const setKrwCoinList = useSetRecoilState(krCoinListState);
-  const setBtcCoinList = useSetRecoilState(btcCoinListState);
-  const setUsdtCoinList = useSetRecoilState(usdtCoinListState);
+  const { setList, isLoading } = useCoinStore();
 
   useEffect(() => {
-    if (initialData.krw.length === 0 || initialData.btc.length === 0) {
+    if (
+      initialData.krw.length === 0 ||
+      initialData.btc.length === 0 ||
+      !isLoading
+    ) {
       return;
     }
 
     const { krw, btc, usdt } = initialData;
 
-    setKrwCoinList({
-      isLoading: false,
-      data: krw,
+    setList({
+      krw,
+      btc,
+      usdt,
     });
-    setBtcCoinList({ isLoading: false, data: btc });
-    setUsdtCoinList({ isLoading: false, data: usdt });
-  }, [initialData, setBtcCoinList, setKrwCoinList, setUsdtCoinList]);
+  }, [initialData, isLoading, setList]);
 };
 
 export default useInitCoinList;

--- a/src/hooks/queries/useTickersData.ts
+++ b/src/hooks/queries/useTickersData.ts
@@ -2,11 +2,10 @@
 
 import { useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useRecoilValue } from 'recoil';
 import sort, { initSort, Sort } from '@/lib/sort';
 import { useCoinStore } from '@/store/coin';
 import { useExchangeStore } from '@/store/exchange';
-import { combineTickers, cryptoSocketState } from '@/store/socket';
+import { useCryptoSocketStore } from '@/store/socket';
 import { Coin } from '@/types/Coin';
 import useCurrencyInfo from './useCurrencyInfo';
 
@@ -32,7 +31,8 @@ const useTickerData = ({
   const { type } = useCoinStore();
 
   const { setExchangeState } = useExchangeStore();
-  const tickerState = useRecoilValue(cryptoSocketState);
+  const { combineTickers } = useCryptoSocketStore();
+
   const {
     data: currencyData = {
       value: 0,
@@ -49,7 +49,7 @@ const useTickerData = ({
         : btcCoinData;
 
     try {
-      const combinedData = combineTickers(originData, tickerState, type); //combineTickers(originData, coinType);
+      const combinedData = combineTickers(originData, type);
 
       const btc = combinedData.find((data) => data.symbol === 'BTC');
       const upbitBTC = btc?.last ?? 0;

--- a/src/hooks/queries/useTickersData.ts
+++ b/src/hooks/queries/useTickersData.ts
@@ -4,15 +4,16 @@ import { useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import sort, { initSort, Sort } from '@/lib/sort';
-import { CoinState, typeState } from '@/store/coin';
+import { useCoinStore } from '@/store/coin';
 import { exchangeState } from '@/store/exchange';
 import { combineTickers, cryptoSocketState } from '@/store/socket';
+import { Coin } from '@/types/Coin';
 import useCurrencyInfo from './useCurrencyInfo';
 
 interface UseTickerDataProps {
-  krwCoinData: CoinState;
-  btcCoinData: CoinState;
-  usdtCoinData: CoinState;
+  krwCoinData: Coin[];
+  btcCoinData: Coin[];
+  usdtCoinData: Coin[];
 }
 
 const useTickerData = ({
@@ -28,7 +29,8 @@ const useTickerData = ({
     per: false,
   });
 
-  const coinType = useRecoilValue(typeState);
+  const { type } = useCoinStore();
+  // const coinType = useRecoilValue(typeState);
   const setExchangeState = useSetRecoilState(exchangeState);
   const tickerState = useRecoilValue(cryptoSocketState);
   const {
@@ -39,15 +41,15 @@ const useTickerData = ({
   } = useCurrencyInfo();
 
   const getTickers = async () => {
-    const { data: originData } =
-      coinType === 'KRW'
+    const originData =
+      type === 'KRW'
         ? krwCoinData
-        : coinType === 'USDT'
+        : type === 'USDT'
         ? usdtCoinData
         : btcCoinData;
 
     try {
-      const combinedData = combineTickers(originData, tickerState, coinType); //combineTickers(originData, coinType);
+      const combinedData = combineTickers(originData, tickerState, type); //combineTickers(originData, coinType);
 
       const btc = combinedData.find((data) => data.symbol === 'BTC');
       const upbitBTC = btc?.last ?? 0;
@@ -81,14 +83,12 @@ const useTickerData = ({
   };
 
   const { data, ...rest } = useQuery({
-    queryKey: ['coins', coinType],
+    queryKey: ['coins', type],
     queryFn: getTickers,
     refetchInterval: 2000,
     refetchIntervalInBackground: true,
     enabled:
-      !!krwCoinData.data.length &&
-      !!btcCoinData.data.length &&
-      !!usdtCoinData.data.length,
+      !!krwCoinData.length && !!btcCoinData.length && !!usdtCoinData.length,
   });
 
   return {

--- a/src/hooks/queries/useTickersData.ts
+++ b/src/hooks/queries/useTickersData.ts
@@ -2,10 +2,10 @@
 
 import { useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import sort, { initSort, Sort } from '@/lib/sort';
 import { useCoinStore } from '@/store/coin';
-import { exchangeState } from '@/store/exchange';
+import { useExchangeStore } from '@/store/exchange';
 import { combineTickers, cryptoSocketState } from '@/store/socket';
 import { Coin } from '@/types/Coin';
 import useCurrencyInfo from './useCurrencyInfo';
@@ -30,8 +30,8 @@ const useTickerData = ({
   });
 
   const { type } = useCoinStore();
-  // const coinType = useRecoilValue(typeState);
-  const setExchangeState = useSetRecoilState(exchangeState);
+
+  const { setExchangeState } = useExchangeStore();
   const tickerState = useRecoilValue(cryptoSocketState);
   const {
     data: currencyData = {

--- a/src/store/coin.ts
+++ b/src/store/coin.ts
@@ -1,47 +1,36 @@
-import { atom } from 'recoil';
-import { generateUid } from '@/lib/utils';
+import { create } from 'zustand';
 import type { Coin } from '@/types/Coin';
 
-export type CoinState = {
+// zustand
+
+type State = {
+  type: string; // KRW | USDT | BTC
+  krwList: Coin[];
+  btcList: Coin[];
+  usdtList: Coin[];
   isLoading: boolean;
-  data: Coin[];
 };
 
-export type WatchListState = Record<'krw' | 'btc', string[]>;
+type Action = {
+  updateType: (type: string) => void;
+  setList: (data: Record<'krw' | 'btc' | 'usdt', Coin[]>) => void;
+};
 
-export const typeState = atom({
-  key: `typeState/${generateUid()}`,
-  default: 'KRW',
-});
-
-export const krCoinListState = atom<CoinState>({
-  key: `krCoinListState/${generateUid()}`,
-  default: {
-    isLoading: true,
-    data: [],
+export const useCoinStore = create<State & Action>((set) => ({
+  type: 'KRW',
+  krwList: [],
+  btcList: [],
+  usdtList: [],
+  isLoading: true,
+  updateType: (type: string) => {
+    set(() => ({ type }));
   },
-});
-
-export const btcCoinListState = atom<CoinState>({
-  key: `btcCoinListState/${generateUid()}`,
-  default: {
-    isLoading: true,
-    data: [],
+  setList: (data: Record<'krw' | 'btc' | 'usdt', Coin[]>) => {
+    set({
+      isLoading: false,
+      krwList: data.krw,
+      btcList: data.btc,
+      usdtList: data.usdt,
+    });
   },
-});
-
-export const usdtCoinListState = atom<CoinState>({
-  key: `usdtCoinListState/${generateUid()}`,
-  default: {
-    isLoading: true,
-    data: [],
-  },
-});
-
-export const watchListState = atom<WatchListState>({
-  key: `watchListState/${generateUid()}`,
-  default: {
-    krw: [],
-    btc: [],
-  },
-});
+}));

--- a/src/store/exchange.ts
+++ b/src/store/exchange.ts
@@ -1,38 +1,41 @@
-import { atom, selector } from 'recoil';
-import { generateUid } from '@/lib/utils';
+import { create } from 'zustand';
 
-type ExchangeState = {
+// zustand
+
+type State = {
   upbitBTC: number;
   binanceBTC: number;
   usdToKrw: number;
+  usdtToKrw: number;
+  bitDiff: number;
   isLoading: boolean;
 };
 
-export const exchangeState = atom<ExchangeState>({
-  key: `exchangeState/${generateUid()}`,
-  default: {
-    upbitBTC: 0,
-    binanceBTC: 0,
-    usdToKrw: 0,
-    isLoading: true,
-  },
-});
+type Action = {
+  setExchangeState: (data: Omit<State, 'usdtToKrw' | 'bitDiff'>) => void;
+};
 
-export const exchangeSelector = selector({
-  key: `exchangeSelector/${generateUid()}`,
-  get: ({ get }) => {
-    const { upbitBTC, binanceBTC, usdToKrw, isLoading } = get(exchangeState);
+export const useExchangeStore = create<State & Action>((set) => ({
+  upbitBTC: 0,
+  binanceBTC: 0,
+  usdToKrw: 0,
+  usdtToKrw: 0,
+  bitDiff: 0,
+  isLoading: true,
+  setExchangeState: (data: Omit<State, 'usdtToKrw' | 'bitDiff'>) => {
+    const { upbitBTC, binanceBTC, usdToKrw, isLoading } = data;
+
     const convertedToKrw = binanceBTC * usdToKrw;
     const bitDiff = ((upbitBTC - convertedToKrw) / convertedToKrw) * 100;
     const usdtToKrw = usdToKrw * (1 + bitDiff / 100);
 
-    return {
-      usdToKrw,
+    set(() => ({
       upbitBTC,
       binanceBTC: convertedToKrw,
-      usdtToKrw: isNaN(usdtToKrw) ? 0 : usdtToKrw,
-      bitDiff: isNaN(bitDiff) || !bitDiff ? 0 : bitDiff,
+      usdToKrw,
+      usdtToKrw,
+      bitDiff,
       isLoading,
-    };
+    }));
   },
-});
+}));

--- a/src/store/socket.ts
+++ b/src/store/socket.ts
@@ -1,24 +1,9 @@
-import { atom } from 'recoil';
-import { generateUid, getPercent } from '@/lib/utils';
+import { create } from 'zustand';
+import { getPercent } from '@/lib/utils';
 import { Coin } from '@/types/Coin';
 import { Exchange } from '@/types/Ticker';
 
-type CryptoSocketState = {
-  tickers: Exchange | null;
-  btcKrw: Record<'upbit' | 'binance', number>;
-};
-
-export const cryptoSocketState = atom<CryptoSocketState>({
-  key: `cryptoSocketState/${generateUid()}`,
-  default: {
-    tickers: null,
-    btcKrw: {
-      upbit: 0,
-      binance: 0,
-    },
-  },
-});
-
+// zustand
 export type CombinedTickers = {
   symbol: string;
   last: number;
@@ -29,128 +14,147 @@ export type CombinedTickers = {
   binanceWarning: boolean;
 };
 
-export const combineTickers = (
-  coinList: Coin[],
-  data: CryptoSocketState,
-  type?: string,
-) => {
-  if (!data.tickers || !data.btcKrw) return [];
+type State = {
+  tickers: Exchange | null;
+  btcKrw: Record<'upbit' | 'binance', number>;
+};
 
-  const { tickers, btcKrw } = data;
+type Action = {
+  setSocketState: (data: State) => void;
+  combineTickers: (coinList: Coin[], type: string) => CombinedTickers[];
+};
 
-  const usdtKRW =
-    tickers.upbit.krw['USDT'] == undefined
-      ? 0
-      : tickers.upbit.krw['USDT'].tradePrice;
+export const useCryptoSocketStore = create<State & Action>((set, get) => ({
+  tickers: null,
+  btcKrw: {
+    upbit: 0,
+    binance: 0,
+  },
+  setSocketState: (data: State) => {
+    set(() => ({
+      ...data,
+    }));
+  },
+  combineTickers: (coinList: Coin[], type: string) => {
+    const { tickers, btcKrw } = get();
 
-  const result: CombinedTickers[] = [{ name: 'BTC' }, ...coinList].map(
-    ({ name }) => {
-      if (type === 'KRW' || name === 'BTC') {
-        const btcConvertedBlast =
-          tickers.binance.btc[name] == undefined
-            ? 0
-            : tickers.binance.btc[name].tradePrice * btcKrw.upbit;
+    if (!tickers || !btcKrw) return [];
 
-        return {
-          symbol: name,
-          last:
-            tickers.upbit.krw[name] == undefined
-              ? 0
-              : tickers.upbit.krw[name].tradePrice,
-          blast:
+    const usdtKRW =
+      tickers.upbit.krw['USDT'] == undefined
+        ? 0
+        : tickers.upbit.krw['USDT'].tradePrice;
+
+    const result: CombinedTickers[] = [{ name: 'BTC' }, ...coinList].map(
+      ({ name }) => {
+        if (type === 'KRW' || name === 'BTC') {
+          const btcConvertedBlast =
             tickers.binance.btc[name] == undefined
               ? 0
-              : tickers.binance.btc[name].tradePrice,
-          convertedBlast: parseFloat(
-            btcConvertedBlast.toFixed(btcConvertedBlast < 1 ? 7 : 2),
-          ),
-          per:
-            tickers.upbit.krw[name] == undefined ||
-            tickers.binance.btc[name] == undefined
-              ? 0
-              : getPercent(
-                  tickers.upbit.krw[name].tradePrice,
-                  tickers.binance.btc[name].tradePrice * btcKrw.upbit,
-                ),
-          upbitChangePrice: tickers.upbit.krw[name]?.changePrice,
-          upbitChangeRate: tickers.upbit.krw[name]?.changeRate,
-          binanceChangePrice: tickers.binance.btc[name]?.changePrice,
-          binanceChangeRate: tickers.binance.btc[name]?.changeRate,
-          upbitWarning: tickers.upbit.krw[name]?.marketWarning === 'CAUTION',
-          binanceWarning:
-            tickers.binance.btc[name]?.marketWarning === 'CAUTION',
-        };
-      }
+              : tickers.binance.btc[name].tradePrice * btcKrw.upbit;
 
-      if (type === 'USDT') {
-        const usdtConvertedBlast =
-          tickers.binance.usdt[name]?.tradePrice == undefined
-            ? 0
-            : tickers.binance.usdt[name].tradePrice * usdtKRW;
+          return {
+            symbol: name,
+            last:
+              tickers.upbit.krw[name] == undefined
+                ? 0
+                : tickers.upbit.krw[name].tradePrice,
+            blast:
+              tickers.binance.btc[name] == undefined
+                ? 0
+                : tickers.binance.btc[name].tradePrice,
+            convertedBlast: parseFloat(
+              btcConvertedBlast.toFixed(btcConvertedBlast < 1 ? 7 : 2),
+            ),
+            per:
+              tickers.upbit.krw[name] == undefined ||
+              tickers.binance.btc[name] == undefined
+                ? 0
+                : getPercent(
+                    tickers.upbit.krw[name].tradePrice,
+                    tickers.binance.btc[name].tradePrice * btcKrw.upbit,
+                  ),
+            upbitChangePrice: tickers.upbit.krw[name]?.changePrice,
+            upbitChangeRate: tickers.upbit.krw[name]?.changeRate,
+            binanceChangePrice: tickers.binance.btc[name]?.changePrice,
+            binanceChangeRate: tickers.binance.btc[name]?.changeRate,
+            upbitWarning: tickers.upbit.krw[name]?.marketWarning === 'CAUTION',
+            binanceWarning:
+              tickers.binance.btc[name]?.marketWarning === 'CAUTION',
+          };
+        }
 
-        return {
-          symbol: name,
-          last:
-            tickers.upbit.usdt[name] == undefined
-              ? 0
-              : tickers.upbit.usdt[name].tradePrice,
-          blast:
+        if (type === 'USDT') {
+          const usdtConvertedBlast =
             tickers.binance.usdt[name]?.tradePrice == undefined
               ? 0
-              : parseFloat(tickers.binance.usdt[name].tradePrice.toFixed(7)),
-          convertedBlast: parseFloat(
-            usdtConvertedBlast.toFixed(usdtConvertedBlast < 1 ? 7 : 2),
-          ),
-          per:
-            tickers.upbit.usdt[name] == undefined ||
-            tickers.binance.usdt[name] == undefined
-              ? 0
-              : getPercent(
-                  tickers.upbit.krw[name].tradePrice,
-                  parseFloat(
-                    (tickers.binance.usdt[name].tradePrice * usdtKRW).toFixed(
-                      4,
+              : tickers.binance.usdt[name].tradePrice * usdtKRW;
+
+          return {
+            symbol: name,
+            last:
+              tickers.upbit.usdt[name] == undefined
+                ? 0
+                : tickers.upbit.usdt[name].tradePrice,
+            blast:
+              tickers.binance.usdt[name]?.tradePrice == undefined
+                ? 0
+                : parseFloat(tickers.binance.usdt[name].tradePrice.toFixed(7)),
+            convertedBlast: parseFloat(
+              usdtConvertedBlast.toFixed(usdtConvertedBlast < 1 ? 7 : 2),
+            ),
+            per:
+              tickers.upbit.usdt[name] == undefined ||
+              tickers.binance.usdt[name] == undefined
+                ? 0
+                : getPercent(
+                    tickers.upbit.krw[name].tradePrice,
+                    parseFloat(
+                      (tickers.binance.usdt[name].tradePrice * usdtKRW).toFixed(
+                        4,
+                      ),
                     ),
                   ),
+            upbitChangePrice: tickers.upbit.usdt[name]?.changePrice,
+            upbitChangeRate: tickers.upbit.usdt[name]?.changeRate,
+            binanceChangePrice: tickers.binance.usdt[name]?.changePrice,
+            binanceChangeRate: tickers.binance.usdt[name]?.changeRate,
+            upbitWarning: tickers.upbit.btc[name]?.marketWarning === 'CAUTION',
+            binanceWarning:
+              tickers.binance.btc[name]?.marketWarning === 'CAUTION',
+          };
+        }
+
+        return {
+          symbol: name,
+          last:
+            tickers.upbit.btc[name] == undefined
+              ? 0
+              : tickers.upbit.btc[name].tradePrice,
+          blast:
+            tickers.binance.btc[name]?.tradePrice == undefined
+              ? 0
+              : tickers.binance.btc[name].tradePrice,
+          convertedBlast: undefined,
+          per:
+            tickers.upbit.btc[name] == undefined ||
+            tickers.binance.btc[name] == undefined
+              ? 0
+              : getPercent(
+                  tickers.upbit.btc[name].tradePrice,
+                  tickers.binance.btc[name].tradePrice,
                 ),
-          upbitChangePrice: tickers.upbit.usdt[name]?.changePrice,
-          upbitChangeRate: tickers.upbit.usdt[name]?.changeRate,
-          binanceChangePrice: tickers.binance.usdt[name]?.changePrice,
-          binanceChangeRate: tickers.binance.usdt[name]?.changeRate,
+          upbitChangePrice: tickers.upbit.btc[name]?.changePrice,
+          upbitChangeRate: tickers.upbit.btc[name]?.changeRate,
+          binanceChangePrice: tickers.binance.btc[name]?.changePrice,
+          binanceChangeRate: tickers.binance.btc[name]?.changeRate,
           upbitWarning: tickers.upbit.btc[name]?.marketWarning === 'CAUTION',
           binanceWarning:
             tickers.binance.btc[name]?.marketWarning === 'CAUTION',
         };
-      }
+      },
+    );
 
-      return {
-        symbol: name,
-        last:
-          tickers.upbit.btc[name] == undefined
-            ? 0
-            : tickers.upbit.btc[name].tradePrice,
-        blast:
-          tickers.binance.btc[name]?.tradePrice == undefined
-            ? 0
-            : tickers.binance.btc[name].tradePrice,
-        convertedBlast: undefined,
-        per:
-          tickers.upbit.btc[name] == undefined ||
-          tickers.binance.btc[name] == undefined
-            ? 0
-            : getPercent(
-                tickers.upbit.btc[name].tradePrice,
-                tickers.binance.btc[name].tradePrice,
-              ),
-        upbitChangePrice: tickers.upbit.btc[name]?.changePrice,
-        upbitChangeRate: tickers.upbit.btc[name]?.changeRate,
-        binanceChangePrice: tickers.binance.btc[name]?.changePrice,
-        binanceChangeRate: tickers.binance.btc[name]?.changeRate,
-        upbitWarning: tickers.upbit.btc[name]?.marketWarning === 'CAUTION',
-        binanceWarning: tickers.binance.btc[name]?.marketWarning === 'CAUTION',
-      };
-    },
-  );
-
-  return result;
-};
+    return result;
+  },
+}));


### PR DESCRIPTION
기존 사용중인 상태관리를 recoil에서 zustand로 교체

교체 결정 주요 원인:
- recoil은 개발 종료가 된 상태로 더 이상 업데이트가 되지 않음, 심지어 메이저 버전도 나오지 않은 상태
- zustand와 비교해서 번들사이즈도 큼 
   - recoil: 79.4kB
   - zustand: 1.2kB
- recoil의 경우 atom, selector 선언시 key값 설정을 해줘야됨, 사용하는데 생각보다 번거로움