### PR TITLE
feat: make useLocalStorage generic

### DIFF
--- a/apps/web/src/components/CoinTable.tsx
+++ b/apps/web/src/components/CoinTable.tsx
@@ -29,14 +29,12 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
   const { type } = useCoinStore();
   const isSmDown = useMedia(getBreakpointQuery(breakpoints.down('sm')), false);
 
-  const { value: krwFavList, updateValue: updateKrwFavList } = useLocalStorage({
-    key: 'krwfav',
-    defaultValue: [],
-  });
-  const { value: btcFavList, updateValue: updateBtcFavList } = useLocalStorage({
-    key: 'btcfav',
-    defaultValue: [],
-  });
+  const { value: krwFavList, updateValue: updateKrwFavList } = useLocalStorage<
+    string[]
+  >('krwfav', []);
+  const { value: btcFavList, updateValue: updateBtcFavList } = useLocalStorage<
+    string[]
+  >('btcfav', []);
 
   const isFavSymbol = useCallback(
     (symbol: string) => {

--- a/apps/web/src/hooks/common/useLocalStorage.ts
+++ b/apps/web/src/hooks/common/useLocalStorage.ts
@@ -4,21 +4,16 @@ import { useState } from 'react';
 import { useIsomorphicLayoutEffect } from '@/hooks';
 import { getLocalStorageData, setLocalStorageData } from '@/lib/storage';
 
-type UseLocalStorageProps = {
-  key: string;
-  defaultValue?: any;
-};
+function useLocalStorage<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(defaultValue);
 
-const useLocalStorage = ({ key, defaultValue }: UseLocalStorageProps) => {
-  const [value, setValue] = useState(defaultValue);
-
-  const updateValue = (value: any) => {
+  const updateValue = (value: T) => {
     setValue(value);
     setLocalStorageData(key, value);
   };
 
   useIsomorphicLayoutEffect(() => {
-    const storedData = getLocalStorageData(key) ?? defaultValue;
+    const storedData = (getLocalStorageData(key) ?? defaultValue) as T;
 
     if (storedData === defaultValue) {
       setLocalStorageData(key, storedData);
@@ -29,6 +24,6 @@ const useLocalStorage = ({ key, defaultValue }: UseLocalStorageProps) => {
   }, []);
 
   return { value, updateValue };
-};
+}
 
 export default useLocalStorage;


### PR DESCRIPTION
## Summary
- make useLocalStorage a generic hook
- update state and setter to use generic type
- adapt CoinTable to use typed local storage

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19c23c3b48323858bd984f4ba80ca