### PR TITLE
feat(api): Add shared caching for market metadata routes

### DIFF
--- a/apps/api/app/api/binance/market/route.ts
+++ b/apps/api/app/api/binance/market/route.ts
@@ -1,5 +1,6 @@
 import { readThroughCache } from "../../lib/cache";
 import { FetchJsonError, fetchJson } from "../../lib/fetchJson";
+import { SymbolInfo } from "./type";
 
 export const BINANCE_MARKET_API_URL =
   "https://api.binance.com/api/v3/exchangeInfo";
@@ -17,7 +18,11 @@ export function resolveBinanceMarketTtlSeconds(): number {
 }
 
 export function fetchBinanceMarketMetadata() {
-  return fetchJson(BINANCE_MARKET_API_URL);
+  return fetchJson(BINANCE_MARKET_API_URL).then((res: any) => ({
+    symbols: res.symbols.filter(
+      (symbol: SymbolInfo) => symbol.status === "TRADING"
+    ),
+  }));
 }
 
 export const config = {

--- a/apps/api/app/api/binance/market/route.ts
+++ b/apps/api/app/api/binance/market/route.ts
@@ -1,18 +1,23 @@
 import { readThroughCache } from "../../lib/cache";
 import { FetchJsonError, fetchJson } from "../../lib/fetchJson";
 
-const API_URL = "https://api.binance.com/api/v3/exchangeInfo";
-const CACHE_KEY = "binance:market:exchange-info";
-const DEFAULT_TTL_SECONDS = 600;
+export const BINANCE_MARKET_API_URL =
+  "https://api.binance.com/api/v3/exchangeInfo";
+export const BINANCE_MARKET_CACHE_KEY = "binance:market:exchange-info";
+export const BINANCE_MARKET_DEFAULT_TTL_SECONDS = 600;
 
-function resolveTtlSeconds(): number {
+export function resolveBinanceMarketTtlSeconds(): number {
   const ttlFromEnv = Number(
-    process.env.BINANCE_MARKET_CACHE_TTL ?? DEFAULT_TTL_SECONDS
+    process.env.BINANCE_MARKET_CACHE_TTL ?? BINANCE_MARKET_DEFAULT_TTL_SECONDS
   );
   if (Number.isFinite(ttlFromEnv) && ttlFromEnv > 0) {
     return Math.floor(ttlFromEnv);
   }
-  return DEFAULT_TTL_SECONDS;
+  return BINANCE_MARKET_DEFAULT_TTL_SECONDS;
+}
+
+export function fetchBinanceMarketMetadata() {
+  return fetchJson(BINANCE_MARKET_API_URL);
 }
 
 export const config = {
@@ -24,9 +29,9 @@ export const config = {
 export async function GET() {
   try {
     const data = await readThroughCache({
-      key: CACHE_KEY,
-      ttlSeconds: resolveTtlSeconds(),
-      fetcher: () => fetchJson(API_URL),
+      key: BINANCE_MARKET_CACHE_KEY,
+      ttlSeconds: resolveBinanceMarketTtlSeconds(),
+      fetcher: fetchBinanceMarketMetadata,
     });
 
     return new Response(JSON.stringify(data), {

--- a/apps/api/app/api/binance/market/type.ts
+++ b/apps/api/app/api/binance/market/type.ts
@@ -1,0 +1,23 @@
+export interface SymbolInfo {
+  symbol: string;
+  status: "TRADING" | "BREAK";
+  baseAsset: string;
+  baseAssetPrecision: number;
+  quoteAsset: string;
+  quotePrecision: number;
+  quoteAssetPrecision: number;
+  baseCommissionPrecision: number;
+  quoteCommissionPrecision: number;
+  icebergAllowed: boolean;
+  ocoAllowed: boolean;
+  quoteOrderQtyMarketAllowed: boolean;
+  isSpotTradingAllowed: boolean;
+  isMarginTradingAllowed: boolean;
+  permissions: ("SPOT" | "MARGIN" | string)[];
+}
+
+export interface ExchangeInfo {
+  timezone: string;
+  serverTime: number;
+  symbols: SymbolInfo[];
+}

--- a/apps/api/app/api/cache/revalidate/route.ts
+++ b/apps/api/app/api/cache/revalidate/route.ts
@@ -1,0 +1,136 @@
+import { refreshCache } from "../../lib/cache";
+import {
+  BINANCE_MARKET_CACHE_KEY,
+  BINANCE_MARKET_DEFAULT_TTL_SECONDS,
+  fetchBinanceMarketMetadata,
+  resolveBinanceMarketTtlSeconds,
+} from "../../binance/market/route";
+import {
+  UPBIT_MARKET_CACHE_KEY,
+  UPBIT_MARKET_DEFAULT_TTL_SECONDS,
+  fetchUpbitMarketMetadata,
+  resolveUpbitMarketTtlSeconds,
+} from "../../upbit/market/route";
+
+interface RevalidateRequestBody {
+  target?: string;
+}
+
+type TargetKey = "upbit-market" | "binance-market";
+
+interface RevalidateTargetConfig {
+  cacheKey: string;
+  resolveTtlSeconds: () => number;
+  fallbackTtlSeconds: number;
+  fetcher: () => Promise<unknown>;
+}
+
+const TARGETS: Record<TargetKey, RevalidateTargetConfig> = {
+  "upbit-market": {
+    cacheKey: UPBIT_MARKET_CACHE_KEY,
+    resolveTtlSeconds: resolveUpbitMarketTtlSeconds,
+    fallbackTtlSeconds: UPBIT_MARKET_DEFAULT_TTL_SECONDS,
+    fetcher: fetchUpbitMarketMetadata,
+  },
+  "binance-market": {
+    cacheKey: BINANCE_MARKET_CACHE_KEY,
+    resolveTtlSeconds: resolveBinanceMarketTtlSeconds,
+    fallbackTtlSeconds: BINANCE_MARKET_DEFAULT_TTL_SECONDS,
+    fetcher: fetchBinanceMarketMetadata,
+  },
+};
+
+function resolveTtl(target: RevalidateTargetConfig): number {
+  const ttl = target.resolveTtlSeconds();
+  if (Number.isFinite(ttl) && ttl > 0) {
+    return Math.floor(ttl);
+  }
+  return target.fallbackTtlSeconds;
+}
+
+function resolveToken(request: Request): string | null {
+  const headerToken = request.headers.get("x-revalidate-token");
+  if (headerToken) {
+    return headerToken;
+  }
+
+  try {
+    const url = new URL(request.url);
+    return url.searchParams.get("token");
+  } catch (err) {
+    console.error("Failed to parse revalidate request URL", err);
+    return null;
+  }
+}
+
+function unauthorizedResponse(): Response {
+  return new Response(JSON.stringify({ error: "Unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function badRequest(message: string): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST(request: Request) {
+  const requiredToken = process.env.MARKET_CACHE_REVALIDATE_TOKEN;
+
+  if (requiredToken) {
+    const providedToken = resolveToken(request);
+    if (providedToken !== requiredToken) {
+      return unauthorizedResponse();
+    }
+  }
+
+  let body: RevalidateRequestBody | null = null;
+  try {
+    body = (await request.json()) as RevalidateRequestBody;
+  } catch (err) {
+    return badRequest("Invalid JSON payload");
+  }
+
+  const targetKey = body?.target as TargetKey | undefined;
+  if (!targetKey) {
+    return badRequest("Missing target field");
+  }
+
+  const target = TARGETS[targetKey];
+  if (!target) {
+    return badRequest(`Unsupported target: ${targetKey}`);
+  }
+
+  const ttlSeconds = resolveTtl(target);
+
+  try {
+    const value = await refreshCache({
+      key: target.cacheKey,
+      ttlSeconds,
+      fetcher: target.fetcher,
+    });
+
+    return new Response(
+      JSON.stringify({
+        target: targetKey,
+        cacheKey: target.cacheKey,
+        ttlSeconds,
+        refreshedAt: new Date().toISOString(),
+        value,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  } catch (err) {
+    console.error("Failed to refresh cache", err);
+    return new Response(JSON.stringify({ error: "Failed to refresh cache" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/apps/api/app/api/lib/cache.test.ts
+++ b/apps/api/app/api/lib/cache.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+
+import { __testing, readThroughCache } from "./cache";
+
+type AsyncTest = () => Promise<void> | void;
+
+const tests: Array<{ name: string; fn: AsyncTest }> = [];
+
+function test(name: string, fn: AsyncTest) {
+  tests.push({ name, fn });
+}
+
+test("returns cached value on subsequent reads", async () => {
+  __testing.clearMemoryCache();
+
+  let callCount = 0;
+  const fetcher = async () => {
+    callCount += 1;
+    return { payload: "first" };
+  };
+
+  const first = await readThroughCache({
+    key: "test:memory",
+    ttlSeconds: 120,
+    fetcher,
+  });
+
+  const second = await readThroughCache({
+    key: "test:memory",
+    ttlSeconds: 120,
+    fetcher,
+  });
+
+  assert.deepEqual(second, first);
+  assert.equal(callCount, 1);
+});
+
+test("re-fetches value after TTL expiration", async () => {
+  __testing.clearMemoryCache();
+
+  let callCount = 0;
+  const fetcher = async () => {
+    callCount += 1;
+    return `value-${callCount}`;
+  };
+
+  const ttlSeconds = 1;
+
+  const first = await readThroughCache({
+    key: "test:ttl",
+    ttlSeconds,
+    fetcher,
+  });
+
+  assert.equal(first, "value-1");
+
+  await new Promise((resolve) => setTimeout(resolve, (ttlSeconds + 0.2) * 1000));
+
+  const second = await readThroughCache({
+    key: "test:ttl",
+    ttlSeconds,
+    fetcher,
+  });
+
+  assert.equal(second, "value-2");
+  assert.equal(callCount, 2);
+});
+
+(async function run() {
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+      console.log(`✓ ${name}`);
+    } catch (err) {
+      console.error(`✗ ${name}`);
+      console.error(err);
+      process.exit(1);
+    }
+  }
+
+  if (tests.length === 0) {
+    console.warn("No tests were executed.");
+    process.exit(1);
+  }
+})();

--- a/apps/api/app/api/lib/cache.test.ts
+++ b/apps/api/app/api/lib/cache.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 
-import { __testing, readThroughCache } from "./cache";
+import { __testing, readThroughCache, refreshCache } from "./cache";
+import { POST as revalidatePost } from "../cache/revalidate/route";
+import {
+  UPBIT_MARKET_CACHE_KEY,
+  UPBIT_MARKET_DEFAULT_TTL_SECONDS,
+} from "../upbit/market/route";
 
 type AsyncTest = () => Promise<void> | void;
 
@@ -64,6 +69,131 @@ test("re-fetches value after TTL expiration", async () => {
 
   assert.equal(second, "value-2");
   assert.equal(callCount, 2);
+});
+
+test("refreshCache bypasses stale memory entry", async () => {
+  __testing.clearMemoryCache();
+
+  let fetchCallCount = 0;
+  const fetcher = async () => {
+    fetchCallCount += 1;
+    return { payload: `value-${fetchCallCount}` };
+  };
+
+  await readThroughCache({
+    key: "test:refresh",
+    ttlSeconds: 120,
+    fetcher,
+  });
+
+  const refreshed = await refreshCache({
+    key: "test:refresh",
+    ttlSeconds: 120,
+    fetcher,
+  });
+
+  assert.deepEqual(refreshed, { payload: "value-2" });
+
+  let fallbackCalls = 0;
+  const cached = await readThroughCache({
+    key: "test:refresh",
+    ttlSeconds: 120,
+    fetcher: async () => {
+      fallbackCalls += 1;
+      return { payload: "from-fetch" };
+    },
+  });
+
+  assert.deepEqual(cached, refreshed);
+  assert.equal(fallbackCalls, 0);
+});
+
+test("revalidate API refreshes upbit market cache", async () => {
+  __testing.clearMemoryCache();
+
+  const originalFetch = globalThis.fetch;
+  let upbitFetchCount = 0;
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+
+    if (url === "https://api.upbit.com/v1/market/all?isDetails=true") {
+      upbitFetchCount += 1;
+      return new Response(
+        JSON.stringify([{ market: "KRW-BTC", korean_name: "비트코인" }]),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    throw new Error(`Unexpected fetch call to ${url}`);
+  }) as typeof fetch;
+
+  process.env.MARKET_CACHE_REVALIDATE_TOKEN = "secret";
+
+  try {
+    const request = new Request("https://example.com/api/cache/revalidate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-revalidate-token": "secret",
+      },
+      body: JSON.stringify({ target: "upbit-market" }),
+    });
+
+    const response = await revalidatePost(request);
+    assert.equal(response.status, 200);
+
+    const payload = (await response.json()) as {
+      target: string;
+      cacheKey: string;
+      value: unknown;
+    };
+
+    assert.equal(payload.target, "upbit-market");
+    assert.equal(payload.cacheKey, UPBIT_MARKET_CACHE_KEY);
+    assert.ok(Array.isArray(payload.value));
+    assert.equal(upbitFetchCount, 1);
+
+    let fallbackCalls = 0;
+    const cached = await readThroughCache({
+      key: UPBIT_MARKET_CACHE_KEY,
+      ttlSeconds: UPBIT_MARKET_DEFAULT_TTL_SECONDS,
+      fetcher: async () => {
+        fallbackCalls += 1;
+        return [];
+      },
+    });
+
+    assert.ok(Array.isArray(cached));
+    assert.equal(fallbackCalls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    delete process.env.MARKET_CACHE_REVALIDATE_TOKEN;
+  }
+});
+
+test("revalidate API rejects missing token when required", async () => {
+  __testing.clearMemoryCache();
+
+  process.env.MARKET_CACHE_REVALIDATE_TOKEN = "secret";
+
+  try {
+    const request = new Request("https://example.com/api/cache/revalidate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ target: "upbit-market" }),
+    });
+
+    const response = await revalidatePost(request);
+    assert.equal(response.status, 401);
+  } finally {
+    delete process.env.MARKET_CACHE_REVALIDATE_TOKEN;
+  }
 });
 
 (async function run() {

--- a/apps/api/app/api/lib/cache.ts
+++ b/apps/api/app/api/lib/cache.ts
@@ -1,0 +1,184 @@
+interface MemoryEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+interface UpstashConfig {
+  url: string;
+  token: string;
+}
+
+interface UpstashPipelineResult {
+  result?: string | null;
+  error?: string;
+}
+
+export interface ReadThroughCacheOptions<T> {
+  key: string;
+  ttlSeconds: number;
+  fetcher: () => Promise<T>;
+}
+
+const memoryCache = new Map<string, MemoryEntry<unknown>>();
+let upstashConfigInitialized = false;
+let upstashConfig: UpstashConfig | null = null;
+let upstashErrorLogged = false;
+
+function logUpstashError(err: unknown) {
+  if (upstashErrorLogged) {
+    return;
+  }
+  upstashErrorLogged = true;
+  console.error("Redis cache error", err);
+}
+
+function getUpstashConfig(): UpstashConfig | null {
+  if (upstashConfigInitialized) {
+    return upstashConfig;
+  }
+
+  upstashConfigInitialized = true;
+
+  const url =
+    process.env.UPSTASH_REDIS_REST_URL ??
+    process.env.REDIS_REST_URL ??
+    process.env.REDIS_URL ??
+    null;
+  const token =
+    process.env.UPSTASH_REDIS_REST_TOKEN ??
+    process.env.REDIS_REST_TOKEN ??
+    process.env.REDIS_TOKEN ??
+    null;
+
+  if (!url || !token) {
+    upstashConfig = null;
+    return upstashConfig;
+  }
+
+  upstashConfig = {
+    url: url.replace(/\/$/, ""),
+    token,
+  };
+
+  return upstashConfig;
+}
+
+function getMemoryEntry<T>(key: string): T | null {
+  const entry = memoryCache.get(key);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= Date.now()) {
+    memoryCache.delete(key);
+    return null;
+  }
+
+  return entry.value as T;
+}
+
+function setMemoryEntry<T>(key: string, value: T, ttlSeconds: number) {
+  if (ttlSeconds <= 0) {
+    memoryCache.delete(key);
+    return;
+  }
+
+  memoryCache.set(key, {
+    value,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  });
+}
+
+async function upstashRequest(body: unknown): Promise<UpstashPipelineResult[]> {
+  const config = getUpstashConfig();
+  if (!config) {
+    return [];
+  }
+
+  try {
+    const response = await fetch(`${config.url}/pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Upstash request failed: ${response.status}`);
+    }
+
+    const data = (await response.json()) as UpstashPipelineResult[];
+    return data;
+  } catch (err) {
+    logUpstashError(err);
+    return [];
+  }
+}
+
+async function upstashGet(key: string): Promise<string | null> {
+  const [result] = await upstashRequest([["GET", key]]);
+
+  if (!result) {
+    return null;
+  }
+
+  if (result.error) {
+    logUpstashError(result.error);
+    return null;
+  }
+
+  return result.result ?? null;
+}
+
+async function upstashSet(
+  key: string,
+  value: string,
+  ttlSeconds: number
+): Promise<void> {
+  if (ttlSeconds <= 0) {
+    await upstashRequest([["SET", key, value]]);
+    return;
+  }
+
+  await upstashRequest([["SETEX", key, String(ttlSeconds), value]]);
+}
+
+export async function readThroughCache<T>(
+  options: ReadThroughCacheOptions<T>
+): Promise<T> {
+  const { key, ttlSeconds, fetcher } = options;
+
+  const cachedValue = getMemoryEntry<T>(key);
+  if (cachedValue !== null) {
+    return cachedValue;
+  }
+
+  const redisValue = await upstashGet(key);
+  if (redisValue !== null) {
+    try {
+      const parsed = JSON.parse(redisValue) as T;
+      setMemoryEntry(key, parsed, ttlSeconds);
+      return parsed;
+    } catch (err) {
+      logUpstashError(err);
+    }
+  }
+
+  const freshValue = await fetcher();
+
+  try {
+    await upstashSet(key, JSON.stringify(freshValue), ttlSeconds);
+  } catch (err) {
+    logUpstashError(err);
+  }
+
+  setMemoryEntry(key, freshValue, ttlSeconds);
+
+  return freshValue;
+}
+
+export const __testing = {
+  clearMemoryCache: () => memoryCache.clear(),
+};

--- a/apps/api/app/api/lib/cache.ts
+++ b/apps/api/app/api/lib/cache.ts
@@ -148,7 +148,7 @@ async function upstashSet(
 export async function readThroughCache<T>(
   options: ReadThroughCacheOptions<T>
 ): Promise<T> {
-  const { key, ttlSeconds, fetcher } = options;
+  const { key, ttlSeconds } = options;
 
   const cachedValue = getMemoryEntry<T>(key);
   if (cachedValue !== null) {
@@ -166,6 +166,14 @@ export async function readThroughCache<T>(
     }
   }
 
+  return refreshCache(options);
+}
+
+export async function refreshCache<T>({
+  key,
+  ttlSeconds,
+  fetcher,
+}: ReadThroughCacheOptions<T>): Promise<T> {
   const freshValue = await fetcher();
 
   try {

--- a/apps/api/app/api/upbit/market/route.ts
+++ b/apps/api/app/api/upbit/market/route.ts
@@ -1,10 +1,25 @@
+import { readThroughCache } from "../../lib/cache";
 import { FetchJsonError, fetchJson } from "../../lib/fetchJson";
 
 const API_URL = "https://api.upbit.com/v1/market/all?isDetails=true";
+const CACHE_KEY = "upbit:market:all";
+const DEFAULT_TTL_SECONDS = 600;
+
+function resolveTtlSeconds(): number {
+  const ttlFromEnv = Number(process.env.UPBIT_MARKET_CACHE_TTL ?? DEFAULT_TTL_SECONDS);
+  if (Number.isFinite(ttlFromEnv) && ttlFromEnv > 0) {
+    return Math.floor(ttlFromEnv);
+  }
+  return DEFAULT_TTL_SECONDS;
+}
 
 export async function GET() {
   try {
-    const data = await fetchJson(API_URL);
+    const data = await readThroughCache({
+      key: CACHE_KEY,
+      ttlSeconds: resolveTtlSeconds(),
+      fetcher: () => fetchJson(API_URL),
+    });
 
     return new Response(JSON.stringify(data), {
       status: 200,

--- a/apps/api/app/api/upbit/market/route.ts
+++ b/apps/api/app/api/upbit/market/route.ts
@@ -1,24 +1,31 @@
 import { readThroughCache } from "../../lib/cache";
 import { FetchJsonError, fetchJson } from "../../lib/fetchJson";
 
-const API_URL = "https://api.upbit.com/v1/market/all?isDetails=true";
-const CACHE_KEY = "upbit:market:all";
-const DEFAULT_TTL_SECONDS = 600;
+export const UPBIT_MARKET_API_URL =
+  "https://api.upbit.com/v1/market/all?isDetails=true";
+export const UPBIT_MARKET_CACHE_KEY = "upbit:market:all";
+export const UPBIT_MARKET_DEFAULT_TTL_SECONDS = 600;
 
-function resolveTtlSeconds(): number {
-  const ttlFromEnv = Number(process.env.UPBIT_MARKET_CACHE_TTL ?? DEFAULT_TTL_SECONDS);
+export function resolveUpbitMarketTtlSeconds(): number {
+  const ttlFromEnv = Number(
+    process.env.UPBIT_MARKET_CACHE_TTL ?? UPBIT_MARKET_DEFAULT_TTL_SECONDS
+  );
   if (Number.isFinite(ttlFromEnv) && ttlFromEnv > 0) {
     return Math.floor(ttlFromEnv);
   }
-  return DEFAULT_TTL_SECONDS;
+  return UPBIT_MARKET_DEFAULT_TTL_SECONDS;
+}
+
+export function fetchUpbitMarketMetadata() {
+  return fetchJson(UPBIT_MARKET_API_URL);
 }
 
 export async function GET() {
   try {
     const data = await readThroughCache({
-      key: CACHE_KEY,
-      ttlSeconds: resolveTtlSeconds(),
-      fetcher: () => fetchJson(API_URL),
+      key: UPBIT_MARKET_CACHE_KEY,
+      ttlSeconds: resolveUpbitMarketTtlSeconds(),
+      fetcher: fetchUpbitMarketMetadata,
     });
 
     return new Response(JSON.stringify(data), {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "test": "pnpm run test:build && pnpm run test:run && pnpm run test:clean",
     "test:build": "tsc -p tsconfig.test.json",
-    "test:run": "node dist-test/cache.test.js",
+    "test:run": "node dist-test/lib/cache.test.js",
     "test:clean": "node -e \"const fs=require('fs'); if (fs.existsSync('dist-test')) fs.rmSync('dist-test', { recursive: true, force: true });\""
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "pnpm run test:build && pnpm run test:run && pnpm run test:clean",
+    "test:build": "tsc -p tsconfig.test.json",
+    "test:run": "node dist-test/cache.test.js",
+    "test:clean": "node -e \"const fs=require('fs'); if (fs.existsSync('dist-test')) fs.rmSync('dist-test', { recursive: true, force: true });\""
   },
   "dependencies": {
     "next": "15.3.5",

--- a/apps/api/tsconfig.test.json
+++ b/apps/api/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist-test",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2019",
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "app/api/lib/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -12,8 +12,6 @@ import { DailyVolumnResponse } from '@/types/DailyVolumn';
 import type { MarketCap } from '@/types/Marketcap';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3001';
-
-const UPBIT_API = `https://api.upbit.com/v1`;
 const BINANCE_API = `https://api.binance.com`;
 
 const api = axios.create({
@@ -30,10 +28,6 @@ const baseApi = axios.create({
   baseURL: BASE_URL,
 });
 
-const _upbitApi = axios.create({
-  baseURL: UPBIT_API,
-});
-
 const binanceApi = axios.create({
   baseURL: BINANCE_API,
 });
@@ -44,7 +38,7 @@ export const getCurrencyInfo = (): Promise<AxiosResponse<Currency>> =>
 export const getUpbitCoinsV2 = async () => {
   try {
     const response = await fetch(`${BASE_URL}/api/upbit/market`, {
-      cache: 'force-cache',
+      cache: 'no-cache',
     });
 
     if (!response.ok) {
@@ -75,6 +69,7 @@ export const getBinanceCoinsV2 = async () => {
     }
 
     const data = await response.json();
+
     return data;
   } catch (error) {
     console.error('Error fetching Binance coins:', error);

--- a/apps/web/src/lib/coin.ts
+++ b/apps/web/src/lib/coin.ts
@@ -1,9 +1,4 @@
-import {
-  getBinanceCoins,
-  getUpbitCoins,
-  getUpbitCoinsV2,
-  getBinanceCoinsV2,
-} from '@/api';
+import { getUpbitCoinsV2, getBinanceCoinsV2 } from '@/api';
 import type { Coin, UpbitCoin } from '@/types/Coin';
 
 type Currency = 'KRW' | 'BTC' | 'USDT';
@@ -100,7 +95,7 @@ export const getCoinsV2 = async (type: Currency) => {
 export const getCoins = async (type: Currency) => {
   try {
     // upbit coin data
-    const { data: upbitData } = await getUpbitCoins();
+    const upbitData = await getUpbitCoinsV2();
     const upbitKrwCoins: UpbitCoin[] = upbitData.filter((coin: UpbitCoin) =>
       coin.market.includes('KRW-'),
     );
@@ -109,7 +104,7 @@ export const getCoins = async (type: Currency) => {
     );
 
     // binance coin data
-    const { data: binanceData } = await getBinanceCoins();
+    const binanceData = await getBinanceCoinsV2();
     const binanceBtcCoins = binanceData.symbols
       .filter(
         (data: any) => data.symbol.endsWith('BTC') && data.status === 'TRADING',


### PR DESCRIPTION
## Summary
- add a reusable Redis-backed read-through cache helper with in-memory fallback
- apply shared caching to the Upbit and Binance market metadata API routes with configurable TTLs
- add TypeScript build-and-run test harness to verify cache reuse and expiry behaviour

## Testing
- pnpm --filter api lint
- pnpm --filter api test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c4ad17a88323aa73e41c404c2ab3)