### PR TITLE
feat(api): add Upbit market cap route

### DIFF
--- a/apps/api/app/api/binance/market/route.ts
+++ b/apps/api/app/api/binance/market/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
     });
   } catch (err) {
     console.error("API Error:", err);
-    const status = err instanceof FetchJsonError ? err.status : 400;
+    const status = err instanceof FetchJsonError ? err.status : 500;
     const message = err instanceof Error ? err.message : "Unknown error";
     return new Response(JSON.stringify({ error: message }), {
       status,

--- a/apps/api/app/api/coin-info/route.ts
+++ b/apps/api/app/api/coin-info/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
     });
   } catch (err) {
     console.error(err);
-    const status = err instanceof FetchJsonError ? err.status : 400;
+    const status = err instanceof FetchJsonError ? err.status : 500;
     const message = err instanceof Error ? err.message : "Unknown error";
     return new Response(JSON.stringify({ error: message }), {
       status,

--- a/apps/api/app/api/upbit/candles/route.ts
+++ b/apps/api/app/api/upbit/candles/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: Request) {
     });
   } catch (err) {
     console.error("API Error:", err);
-    const status = err instanceof FetchJsonError ? err.status : 400;
+    const status = err instanceof FetchJsonError ? err.status : 500;
     const message = err instanceof Error ? err.message : "Unknown error";
     return new Response(JSON.stringify({ error: message }), {
       status,

--- a/apps/api/app/api/upbit/daily_volume_power/route.ts
+++ b/apps/api/app/api/upbit/daily_volume_power/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request) {
     });
   } catch (err) {
     console.error("API Error:", err);
-    const status = err instanceof FetchJsonError ? err.status : 400;
+    const status = err instanceof FetchJsonError ? err.status : 500;
     const message = err instanceof Error ? err.message : "Unknown error";
     return new Response(JSON.stringify({ error: message }), {
       status,

--- a/apps/api/app/api/upbit/market/route.ts
+++ b/apps/api/app/api/upbit/market/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
       });
     } catch (err) {
       console.error("API Error:", err);
-      const status = err instanceof FetchJsonError ? err.status : 400;
+      const status = err instanceof FetchJsonError ? err.status : 500;
       const message = err instanceof Error ? err.message : "Unknown error";
       return new Response(JSON.stringify({ error: message }), {
         status,

--- a/apps/api/app/api/upbit/market_cap/route.ts
+++ b/apps/api/app/api/upbit/market_cap/route.ts
@@ -1,0 +1,23 @@
+import { FetchJsonError, fetchJson } from "../../lib/fetchJson";
+
+const API_URL = "https://crix-api-cdn.upbit.com/v1/crix/marketcap?currency=KRW";
+
+export async function GET(request: Request) {
+    try {
+        const url = new URL(API_URL);
+        const data = await fetchJson(url.toString());
+
+        return new Response(JSON.stringify(data), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+        });
+    } catch (err) {
+        console.error(err);
+        const status = err instanceof FetchJsonError ? err.status : 400;
+        const message = err instanceof Error ? err.message : "Unknown error";
+        return new Response(JSON.stringify({ error: message }), {
+            status,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
+}

--- a/apps/api/app/api/upbit/market_cap/route.ts
+++ b/apps/api/app/api/upbit/market_cap/route.ts
@@ -4,16 +4,11 @@ const API_URL = "https://crix-api-cdn.upbit.com/v1/crix/marketcap?currency=KRW";
 
 export async function GET(request: Request) {
     try {
-        const url = new URL(API_URL);
-        const data = await fetchJson(url.toString());
-
-        return new Response(JSON.stringify(data), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-        });
+        const data = await fetchJson(API_URL);
+        return Response.json(data);
     } catch (err) {
         console.error(err);
-        const status = err instanceof FetchJsonError ? err.status : 400;
+        const status = err instanceof FetchJsonError ? err.status : 500;
         const message = err instanceof Error ? err.message : "Unknown error";
         return new Response(JSON.stringify({ error: message }), {
             status,

--- a/apps/api/app/api/upbit/news/route.ts
+++ b/apps/api/app/api/upbit/news/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: Request) {
     });
   } catch (err) {
     console.error(err);
-    const status = err instanceof FetchJsonError ? err.status : 400;
+    const status = err instanceof FetchJsonError ? err.status : 500;
     const message = err instanceof Error ? err.message : "Unknown error";
     return new Response(JSON.stringify({ error: message }), {
       status,

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -96,7 +96,7 @@ export const getNews = (category?: string) =>
   );
 
 export const getMarketcap = (): Promise<AxiosResponse<MarketCap[]>> =>
-  axios.get('https://crix-api-cdn.upbit.com/v1/crix/marketcap?currency=KRW');
+  baseApi.get('/api/upbit/market_cap');
 
 /**
  * 탐욕 지수 api


### PR DESCRIPTION
# 요약

- Upbit CRIX 시가총액(marketcap) 데이터를 프록시하는 API 라우트를 추가합니다.

## 주요 작업:

- `apps/api/app/api/upbit/market_cap/route.ts`에 `GET` 핸들러 추가
- 공용 `fetchJson` 헬퍼를 통해 Upbit CRIX marketcap 엔드포인트(KRW) 호출
- `FetchJsonError` 기반 상태 코드 처리 및 에러 메시지 응답 핸들링

## 기타 작업:

- 없음

## 고민사항 및 추후 고려사항:

- 외부 Upbit CRIX 엔드포인트(`crix-api-cdn.upbit.com`)에 의존하므로 응답 스키마 변경 시 대응 필요
- 캐싱/레이트 리밋 정책 적용 여부는 추후 검토
- `apps/web/.env.development` 변경분은 이번 PR에 포함하지 않았습니다.