### PR TITLE
fix(api): defer Supabase credential read to fix build

### DIFF
--- a/apps/api/app/api/lib/supabase.ts
+++ b/apps/api/app/api/lib/supabase.ts
@@ -3,8 +3,6 @@ import { getSupabaseCredentials } from "./env";
 
 type SupabaseDatabase = any; // Replace with your generated types when available.
 
-const { url, serviceRoleKey } = getSupabaseCredentials();
-
 const supabaseOptions = {
   auth: {
     autoRefreshToken: false,
@@ -17,6 +15,7 @@ let client: SupabaseClient<SupabaseDatabase> | null = null;
 
 export function getSupabaseClient() {
   if (!client) {
+    const { url, serviceRoleKey } = getSupabaseCredentials();
     client = createClient<SupabaseDatabase>(url, serviceRoleKey, supabaseOptions);
   }
   return client;


### PR DESCRIPTION
# 요약

- `next build` 시 Supabase 환경변수가 없으면 빌드가 실패하던 문제를 수정합니다.

## 주요 작업:

- `getSupabaseCredentials()` 호출을 모듈 최상단에서 `getSupabaseClient()` 내부로 이동하여 환경변수를 지연(lazy) 로딩하도록 변경
- 모듈 import 시점이 아닌 요청(runtime) 시점에 환경변수를 읽도록 하여, 누락 시에도 기존 GET 핸들러의 try/catch 폴백 경로에서 처리되도록 함

## 기타 작업:

- 없음

## 고민사항 및 추후 고려사항:

- 기존에는 모듈 import 시점에 `getSupabaseCredentials()`가 실행되어, `SUPABASE_URL` 미설정 시 throw된 에러가 GET 핸들러의 try/catch를 우회해 `next build`의 page-data 수집 단계에서 빌드를 실패시켰습니다.
- 빌드 정상 통과를 확인했으며, 모든 API 라우트는 `ƒ (Dynamic)`으로 처리됩니다.
- `apps/web/.env.development` 변경분은 이번 PR에 포함하지 않았습니다.