### PR TITLE
fix(web): correct worker script paths so SharedWorker actually loads

### DIFF
--- a/apps/web/src/lib/ticker-source/dedicatedWorkerSource.ts
+++ b/apps/web/src/lib/ticker-source/dedicatedWorkerSource.ts
@@ -6,7 +6,7 @@ import {
   TickerSourceErrorHandler,
 } from './types';
 
-const DEDICATED_WORKER_URL = '/public/workers/workers/dedicated.worker.js';
+const DEDICATED_WORKER_URL = '/workers/workers/dedicated.worker.js';
 
 /**
  * A per-tab Dedicated Worker running a single bridge WebSocket off the main thread.

--- a/apps/web/src/lib/ticker-source/sharedWorkerSource.ts
+++ b/apps/web/src/lib/ticker-source/sharedWorkerSource.ts
@@ -7,7 +7,7 @@ import {
 } from './types';
 
 // Keep the same path convention as the rest of the app (see SharedWorkerProvider history).
-const SHARED_WORKER_URL = '/public/workers/workers/shared.worker.js';
+const SHARED_WORKER_URL = '/workers/workers/shared.worker.js';
 
 /**
  * One SharedWorker holds a single bridge WebSocket shared across all tabs.


### PR DESCRIPTION
# 요약

- 실시간 시세용 워커 스크립트 경로가 잘못되어 SharedWorker(및 Dedicated Worker 폴백)가 로드되지 않고 매번 메인 스레드로 폴백되던 문제를 수정합니다.

## 주요 작업:

- `sharedWorkerSource.ts` / `dedicatedWorkerSource.ts`의 워커 URL에서 `/public` 접두어 제거 (`/public/workers/workers/*.worker.js` → `/workers/workers/*.worker.js`)
- Next.js는 `public/` 디렉터리를 루트(`/`)로 서빙하므로 기존 경로는 404를 반환했고, 그 결과 워커 로드 실패 → 메인 스레드 WebSocket 폴백이 발생했음

## 기타 작업:

- 없음

## 고민사항 및 추후 고려사항:

- **검증**: dev 서버에서 기존 경로는 `HTTP 404`, 수정 후 경로(`/workers/workers/*.worker.js`)는 `HTTP 200` 확인. `new URL(변수, import.meta.url)`은 런타임에 origin 기준으로 해석되므로 정상 연결됨.
- 이 버그로 인해 모든 탭이 메인 스레드에서 각자 WebSocket을 여는 상태였고(단일 공유 소켓 아키텍처 무력화), 초기 로딩 시 4초 워치독 지연이 매번 발생했습니다.
- 브라우저에서의 SharedWorker 핸드셰이크 end-to-end 확인(DevTools → Application → Shared workers)은 리뷰 시 한 번 더 확인하면 좋습니다.