### PR TITLE
docs(claude): document esbuild worker bundling and string-path loading

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,8 @@
 ## Must-know rules
 
 - **Real-time data** flows through the SharedWorker (`apps/web/workers/shared.worker.ts`) — never open redundant WebSocket connections in the main thread.
-- **`apps/web` build compiles workers first**: `pnpm build` = `pnpm build:workers && next build`. After editing `apps/web/workers/`, rebuild (or run `watch:workers`).
+- **`apps/web` bundles workers first**: `pnpm build` = `pnpm build:workers && next build` — esbuild bundles `workers/*.worker.ts` into self-contained `public/workers/workers/*.js` (NOT tsc; tsc leaves unresolvable `@/` aliases). After editing `apps/web/workers/`, rebuild (or run `watch:workers`).
+- **Loading a worker**: pass the compiled path as a plain string — `new SharedWorker('/workers/workers/shared.worker.js', { type: 'module' })`. Do NOT wrap in `new URL(path, import.meta.url)` (webpack inlines `import.meta.url` as `file://` → fails to load). Served from `/workers/...` (no `/public` prefix).
 - **Data fetching**: use the centralized API layer (`apps/web/src/api/index.ts`) and React Query hooks in `apps/web/src/hooks/queries/`.
 - **Styling**: Tailwind for layout/utilities, Emotion for dynamic styles. Run `pnpm lint` + `pnpm lint:css` (web) before finishing.
 

--- a/.claude/reference/architecture.md
+++ b/.claude/reference/architecture.md
@@ -58,8 +58,8 @@ Details: `apps/web/src/lib/ticker-source/README.md`.
 
 ```mermaid
 flowchart LR
-    A[edit workers/*.ts] --> B["build:workers<br/>(tsc -p tsconfig.worker.json)"]
-    B --> C[public/workers/*.js<br/>ES modules]
+    A[edit workers/*.ts] --> B["build:workers<br/>(esbuild --bundle)"]
+    B --> C[public/workers/workers/*.js<br/>self-contained ESM]
     C --> D[next build]
     D --> E[.next output]
 ```
@@ -75,7 +75,8 @@ flowchart LR
 - **Formatting**: follow the Prettier/ESLint/Stylelint configs; run `pnpm lint` (and `lint:css` in web) to verify.
 
 ## Build Quirks
-- **Workers must compile before the Next build.** `build:workers` (`tsc -p tsconfig.worker.json`) emits to `public/workers/`. If you change anything under `apps/web/workers/`, rebuild (or run `watch:workers`).
+- **Workers must bundle before the Next build.** `build:workers` runs **esbuild** (`--bundle --format=esm`) over `workers/*.worker.ts` → self-contained `public/workers/workers/*.js`. tsc was insufficient: it leaves `@/` path aliases the browser can't resolve in a module worker. Rebuild (or `watch:workers`) after editing `apps/web/workers/`.
+- **Load workers by string path**, e.g. `new SharedWorker('/workers/workers/shared.worker.js', { type: 'module' })` — files in `public/` serve at `/` (no `/public` prefix). Avoid `new URL(path, import.meta.url)`: webpack inlines `import.meta.url` as a `file://` path, so the worker resolves to `file:///workers/...` and silently fails → every tier downgrades to main-thread.
 - **Hybrid routing in web**: `apps/web/src/app/` (App Router) and a legacy `apps/web/src/pages/` (Pages Router) coexist.
 - **api dev uses Turbopack** (`next dev --turbopack`).
 - **Env files** are per-app: `apps/web/.env.development`, `apps/api/.env.development` (Supabase URL + keys; see `apps/api/.env.example`). There is no root env file.


### PR DESCRIPTION
# 요약

- PR #28(tsc → esbuild 워커 번들링)이 머지된 뒤, `.claude` 문서에 남아 있던 옛 워커 빌드/로딩 설명을 최신화합니다.

## 주요 작업:

- `.claude/CLAUDE.md` (Must-know rules): `build:workers`가 esbuild로 `workers/*.worker.ts`를 자체 완결 `public/workers/workers/*.js`로 번들한다는 점 명시 + 워커 로딩 시 `new URL(path, import.meta.url)` 금지(문자열 경로 직접 전달) gotcha 추가.
- `.claude/reference/architecture.md`: 빌드 파이프라인 mermaid를 `tsc -p tsconfig.worker.json` → `esbuild --bundle`로 수정, Build Quirks 항목 갱신 + 로딩 gotcha 추가.

## 기타 작업:

- 없음 (문서만 변경)

## 고민사항 및 추후 고려사항:

- 원래 PR #28에 함께 담으려 했으나 PR이 먼저 머지되어, 문서 변경만 별도 브랜치(`docs/worker-build-notes`)로 분리해 올립니다.
- 코드 변경 없음 — 리뷰 부담 낮음.