### PR TITLE
chore(web): bind dev server to 0.0.0.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:share": "next dev -H 0.0.0.0",
     "build": "pnpm build:workers && next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
# 요약

로컬 개발 서버를 모든 네트워크 인터페이스에 바인딩하여 같은 네트워크의 다른 기기에서도 접속할 수 있게 합니다.

## 주요 작업:

- `apps/web`의 `dev` 스크립트를 `next dev`에서 `next dev -H 0.0.0.0`으로 변경
- LAN 내 모바일 기기 등에서 개발 서버 접속 가능 (실기기 테스트 용이)

## 기타 작업:

- 없음

## 고민사항 및 추후 고려사항:

- `0.0.0.0` 바인딩은 로컬 개발 환경 전용이며 동일 네트워크 내 노출을 전제로 합니다. 신뢰할 수 없는 네트워크에서는 주의가 필요합니다.