### PR TITLE
fix(web): reap garbage-collected SharedWorker ports periodically

### DIFF
--- a/apps/web/public/workers/workers/shared.worker.js
+++ b/apps/web/public/workers/workers/shared.worker.js
@@ -192,6 +192,18 @@ var BridgeWorkerCore = class {
   }
 };
 
+// src/lib/ws/reapDeadPorts.ts
+function reapDeadPorts(ports2) {
+  return ports2.filter((port) => {
+    if (port.isAlive()) return true;
+    try {
+      port.close();
+    } catch {
+    }
+    return false;
+  });
+}
+
 // src/lib/ws/worker-messages.ts
 var WorkerMsg = {
   Init: "init",
@@ -203,11 +215,27 @@ var WorkerMsg = {
 
 // workers/shared.worker.ts
 var _self = self;
+var SWEEP_INTERVAL_MS = 1e4;
 var core = new BridgeWorkerCore();
 var ports = [];
+var sweepTimer = null;
+function startSweep() {
+  if (sweepTimer) return;
+  sweepTimer = setInterval(() => {
+    ports = reapDeadPorts(ports);
+    stopSweepIfEmpty();
+  }, SWEEP_INTERVAL_MS);
+}
+function stopSweepIfEmpty() {
+  if (ports.length === 0 && sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}
 _self.onconnect = (e) => {
   const port = new BrowserPort(e.ports[0]);
   ports.push(port);
+  startSweep();
   console.log("Port connected:", port);
   port.addEventListener("message", (e2) => {
     const { type, payload } = e2.data;
@@ -222,6 +250,7 @@ _self.onconnect = (e) => {
     if (type === WorkerMsg.Disconnect) {
       ports = ports.filter((p) => p !== port);
       port.close();
+      stopSweepIfEmpty();
       console.log("Port disconnected:", port);
       return;
     }
@@ -242,6 +271,7 @@ _self.onconnect = (e) => {
           }
         });
         ports = alive;
+        stopSweepIfEmpty();
       } catch (error) {
         console.error("Error sending data:", error);
       }

--- a/apps/web/src/lib/ticker-source/README.md
+++ b/apps/web/src/lib/ticker-source/README.md
@@ -51,6 +51,17 @@ flowchart LR
     C -. WebSocket .-> EX
 ```
 
+## Zombie port cleanup (SharedWorker tier)
+
+The `SharedWorker` keeps one `MessagePort` per connected tab in a `ports[]` list and broadcasts each payload to all of them. A tab that closes *gracefully* sends a `Disconnect` message and is removed immediately. But a tab that vanishes **without** one — a crash, a force-kill, or a browser that never fires `unload` — leaves a **zombie port** behind.
+
+These zombies are not caught reactively: posting to a dead `MessagePort` is a silent no-op, not a throw, so the broadcast `try/catch` never fires for them. Instead they are reaped on a timer:
+
+- Each port is wrapped in `BrowserPort`, which holds the `MessagePort` in a `WeakRef`. Once the owning tab is gone and the port is collected, `deref()` returns `undefined` and `isAlive()` becomes `false`.
+- `reapDeadPorts(ports)` (`@/lib/ws/reapDeadPorts`) closes and drops those ports. The worker runs it on a 10s `setInterval`, started on the first connection and stopped once the list empties (so the worker isn't pinned alive after the last tab leaves).
+
+**Caveat — cleanup timing is non-deterministic.** A zombie is only removed *after* GC has actually collected its `MessagePort`, and GC timing is up to V8 (no memory pressure → it may run much later). So a vanished tab can linger in `ports[]` until the next collection; shortening the sweep interval doesn't help because there is nothing to reap until GC runs. If a bounded cleanup latency is ever required, extend `reapDeadPorts` with a per-port `lastSeen` heartbeat timeout (each inbound message refreshes it; the 1s `requestTickers` poll keeps live tabs fresh) and reap on `idle > N` in addition to the `deref()` check.
+
 ## Files
 
 | File | Role |
@@ -65,5 +76,7 @@ flowchart LR
 | `@/lib/ws/bridgeMapper.ts` | Pure `UnifiedTicker` → `TickerPayload` mapping |
 | `@/lib/ws/bridgeWorkerCore.ts` | `BridgeWorkerCore` — shared bridge lazy-init + payload logic for both workers |
 | `@/lib/ws/worker-messages.ts` | `WorkerMsg` — message protocol constants (SSOT) shared by workers and sources |
+| `@/lib/ws/reapDeadPorts.ts` | Drops `SharedWorker` ports whose `MessagePort` has been GC'd (zombie cleanup) |
+| `@/lib/browser-port.ts` | `BrowserPort` — `WeakRef`-wrapped `MessagePort` exposing `isAlive()` |
 
 The worker tiers load the compiled workers from `apps/web/workers/` (`shared.worker.ts`, `dedicated.worker.ts`); all three tiers build a single `BridgeWebSocket` (`@/lib/ws/bridgeWS`) that connects to the unified 시세 브릿지 and maps `UnifiedTicker` → `TickerPayload` via `@/lib/ws/bridgeMapper`. Both workers share `BridgeWorkerCore` so their bridge lifecycle cannot drift apart. Bridge config (`wsBase`/`token`) is read from `NEXT_PUBLIC_*` env in the Next bundle via `getBridgeConfig()` (`bridgeConfig.ts`) — env is unavailable inside the tsc worker build, so the main-thread sources read it and pass it to the workers via an `init` message. Message types use the `WorkerMsg` constants (`@/lib/ws/worker-messages`) on both sides.

--- a/apps/web/src/lib/ws/reapDeadPorts.test.ts
+++ b/apps/web/src/lib/ws/reapDeadPorts.test.ts
@@ -1,0 +1,40 @@
+import type BrowserPort from '@/lib/browser-port';
+import { reapDeadPorts } from '@/lib/ws/reapDeadPorts';
+
+/** Mock with a togglable isAlive() (simulating WeakRef.deref() => undefined). */
+class MockPort {
+  constructor(private alive: boolean) {}
+  isAlive() {
+    return this.alive;
+  }
+  close = jest.fn();
+}
+
+const mk = (alive: boolean) => new MockPort(alive) as unknown as BrowserPort;
+
+describe('reapDeadPorts', () => {
+  it('keeps ports whose MessagePort is still reachable', () => {
+    const a = mk(true);
+    const b = mk(true);
+    expect(reapDeadPorts([a, b])).toEqual([a, b]);
+    expect(a.close).not.toHaveBeenCalled();
+    expect(b.close).not.toHaveBeenCalled();
+  });
+
+  it("closes and drops ports whose MessagePort has been GC'd", () => {
+    const live = mk(true);
+    const dead = mk(false);
+
+    const result = reapDeadPorts([live, dead]);
+
+    expect(result).toEqual([live]);
+    expect(dead.close).toHaveBeenCalled();
+    expect(live.close).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array when every port is dead', () => {
+    const dead = mk(false);
+    expect(reapDeadPorts([dead])).toEqual([]);
+    expect(dead.close).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ws/reapDeadPorts.ts
+++ b/apps/web/src/lib/ws/reapDeadPorts.ts
@@ -1,0 +1,22 @@
+import type BrowserPort from '@/lib/browser-port';
+
+/**
+ * Keep only ports whose MessagePort is still reachable, closing and dropping the
+ * rest. When a tab goes away its MessagePort eventually becomes unreachable and
+ * the port's WeakRef deref()s to undefined (so `isAlive()` returns false).
+ *
+ * NOTE: this relies on the garbage collector having actually collected the port,
+ * so cleanup timing is non-deterministic — a vanished tab can linger in the list
+ * until the next GC happens to run.
+ */
+export function reapDeadPorts(ports: BrowserPort[]): BrowserPort[] {
+  return ports.filter((port) => {
+    if (port.isAlive()) return true;
+    try {
+      port.close();
+    } catch {
+      // ignore — already gone
+    }
+    return false;
+  });
+}

--- a/apps/web/workers/shared.worker.ts
+++ b/apps/web/workers/shared.worker.ts
@@ -1,17 +1,40 @@
 import BrowserPort from '@/lib/browser-port';
 import { BridgeWorkerCore } from '@/lib/ws/bridgeWorkerCore';
+import { reapDeadPorts } from '@/lib/ws/reapDeadPorts';
 import { WorkerMsg } from '@/lib/ws/worker-messages';
 
 const _self = self as unknown as SharedWorkerGlobalScope;
 
 // chrome://inspect/#workers
 
+const SWEEP_INTERVAL_MS = 10_000;
+
 const core = new BridgeWorkerCore();
 let ports: BrowserPort[] = [];
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+// Periodically drop ports whose MessagePort has been garbage-collected (the
+// owning tab is gone). The timer only runs while ports are connected so the
+// worker isn't pinned alive after the last tab leaves.
+function startSweep() {
+  if (sweepTimer) return;
+  sweepTimer = setInterval(() => {
+    ports = reapDeadPorts(ports);
+    stopSweepIfEmpty();
+  }, SWEEP_INTERVAL_MS);
+}
+
+function stopSweepIfEmpty() {
+  if (ports.length === 0 && sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}
 
 _self.onconnect = (e: MessageEvent) => {
   const port = new BrowserPort(e.ports[0]);
   ports.push(port);
+  startSweep();
   console.log('Port connected:', port);
 
   port.addEventListener('message', (e) => {
@@ -31,6 +54,7 @@ _self.onconnect = (e: MessageEvent) => {
     if (type === WorkerMsg.Disconnect) {
       ports = ports.filter((p) => p !== port);
       port.close();
+      stopSweepIfEmpty();
       console.log('Port disconnected:', port);
       return;
     }
@@ -55,6 +79,7 @@ _self.onconnect = (e: MessageEvent) => {
           }
         });
         ports = alive;
+        stopSweepIfEmpty();
       } catch (error) {
         console.error('Error sending data:', error);
       }


### PR DESCRIPTION
# 요약

graceful Disconnect 없이 사라진 탭(크래시·강제 종료·`unload` 미발화 브라우저)이 SharedWorker에 남긴 좀비 포트를, GC로 수거된 포트를 주기적으로 걷어내 정리합니다.

## 주요 작업:

- **`reapDeadPorts()` 추가** (`src/lib/ws/reapDeadPorts.ts`): WeakRef로 감싼 MessagePort가 GC되면 `deref()`가 `undefined`가 되어 `isAlive()`가 false가 됨. 그런 포트를 `close` 후 배열에서 제거하는 순수 함수 + 단위 테스트.
- **`shared.worker.ts`에서 10초 주기 sweep**: `setInterval`로 `reapDeadPorts(ports)` 실행. 타이머는 **포트가 연결돼 있을 때만** 돌도록(연결 시 시작, 비면 정지) 해서 마지막 탭이 떠난 뒤 워커가 영원히 살아있지 않게 함.

## 기타 작업:

- 워커 번들 재빌드(`public/workers/workers/shared.worker.js`) — 커밋된 산출물 동기화.

## 고민사항 및 추후 고려사항:

- 기존 reactive 정리(`postMessage` try/catch)는 사실상 동작하지 않았음 — MessagePort 스펙상 상대 포트가 죽어도 `postMessage`는 throw하지 않고 조용히 무시되기 때문.
- **정리 시점이 비결정적**: `deref()`가 undefined가 되려면 GC가 실제로 그 포트를 수거해야 하므로, 사라진 탭이 다음 GC가 돌 때까지 목록에 남아있을 수 있음. "정확히 N초 후 정리" 같은 보장은 없음. 결정적 정리가 필요하면 lastSeen 기반 타임아웃 방식으로 확장 가능(이번 PR 범위 밖).
- 이번 범위는 **포트 좀비 정리**로 한정. 업스트림 브리지 WebSocket teardown, 클라이언트 disconnect 신호 신뢰성 개선(`unload` → `pagehide`/`visibilitychange`)은 후속 과제로 의도적으로 제외.
- 수동 확인: `chrome://inspect/#workers`에서 탭 2개 중 하나를 `chrome://crash`로 죽이면, GC 수거 후 sweep에서 좀비 포트가 제거됨.