### PR TITLE
feat(web): add dark mode and coin symbol search

### DIFF
--- a/apps/web/src/app/(main)/components/CoinTable.tsx
+++ b/apps/web/src/app/(main)/components/CoinTable.tsx
@@ -23,9 +23,10 @@ import { TickerType } from '@/types/Coin';
 type Props = {
   coinList: CombinedTickers[];
   handleSort: (type: Sort) => () => void;
+  isLoading?: boolean;
 };
 
-const CoinTable = ({ coinList, handleSort }: Props) => {
+const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
   const { type } = useCoinStore();
   const isSmDown = useMedia(getBreakpointQuery(breakpoints.down('sm')), false);
 
@@ -112,7 +113,18 @@ const CoinTable = ({ coinList, handleSort }: Props) => {
       }
       body={
         !filteredCointList.length ? (
-          <Table.Skeleton />
+          isLoading ? (
+            <Table.Skeleton />
+          ) : (
+            <div
+              className={cn(
+                'w-full bg-surface py-10',
+                'text-center text-sm text-fg-muted',
+              )}
+            >
+              검색 결과가 없습니다.
+            </div>
+          )
         ) : (
           <>
             {filteredCointList.map((data) => (

--- a/apps/web/src/app/(main)/components/Contents/index.tsx
+++ b/apps/web/src/app/(main)/components/Contents/index.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useState } from 'react';
+import { useDebounce } from 'react-use';
+import Input from '@/components/ui/Input';
 import { useTickersData } from '@/hooks';
 import { useCoinList } from '@/hooks';
 import { cn } from '@/lib/utils';
@@ -8,14 +11,33 @@ import MarketLinks from '../MarketLinks';
 
 export default function Contents() {
   const { krwCoinData, btcCoinData, usdtCoinData } = useCoinList();
-  const { data, handleSort } = useTickersData({
+  const { data, handleSort, setKeyword } = useTickersData({
     krwCoinData,
     btcCoinData,
     usdtCoinData,
   });
+  const [inputValue, setInputValue] = useState('');
+
+  useDebounce(() => setKeyword(inputValue), 200, [inputValue]);
 
   return (
     <>
+      <div className={cn('px-2 pt-2 max-md:px-1')}>
+        <Input
+          type="search"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder="코인 검색 (예: BTC)"
+          aria-label="코인 검색"
+          className={cn(
+            'w-full rounded-md px-3 py-2 text-sm',
+            'bg-surface text-fg border border-border',
+            'placeholder:text-fg-muted',
+            'focus:outline-none focus:border-[#3772ff]',
+            'max-md:text-xs',
+          )}
+        />
+      </div>
       <div
         className={cn(
           'max-md:text-xs max-sm:text-[10px]',
@@ -25,7 +47,11 @@ export default function Contents() {
         <p className={cn('m-2 max-md:m-1')}>암호화폐 - {data?.length ?? 0}개</p>
         <MarketLinks />
       </div>
-      <CoinTable coinList={data ?? []} handleSort={handleSort} />
+      <CoinTable
+        coinList={data ?? []}
+        handleSort={handleSort}
+        isLoading={data === undefined}
+      />
     </>
   );
 }

--- a/apps/web/src/app/(main)/components/MarketLinks/index.tsx
+++ b/apps/web/src/app/(main)/components/MarketLinks/index.tsx
@@ -59,7 +59,7 @@ export default function MarketLinks() {
               <Dropdown.Content>
                 <Dropdown.Body
                   className={cn(
-                    'min-w-[180px] bg-white',
+                    'min-w-[180px] bg-surface',
                     'max-md:min-w-[150px]',
                   )}
                 >

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,9 +21,14 @@ export const viewport: Viewport = {
   userScalable: false,
 };
 
+const themeInitScript = `(function(){try{var t=localStorage.getItem('theme');if(t!=='light'&&t!=='dark'){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}var r=document.documentElement;if(t==='dark'){r.classList.add('dark');}r.style.colorScheme=t;}catch(e){}})();`;
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="ko" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body>
         <Providers>
           <Initialize />

--- a/apps/web/src/app/trading-view/components/CoinInfo/CoinInfoSkeleton.tsx
+++ b/apps/web/src/app/trading-view/components/CoinInfo/CoinInfoSkeleton.tsx
@@ -5,7 +5,7 @@ export const CoinInfoSkeleton = () => {
   return (
     <Flex
       flexDirection="column"
-      className="min-h-[550px] bg-white px-3 py-5"
+      className="min-h-[550px] bg-surface px-3 py-5"
       gap="32px"
       isFull
     >

--- a/apps/web/src/app/trading-view/components/CoinInfo/index.tsx
+++ b/apps/web/src/app/trading-view/components/CoinInfo/index.tsx
@@ -27,7 +27,7 @@ const CoinInfo = ({ code }: Props) => {
   return (
     <Flex
       flexDirection="column"
-      className="min-h-[550px] bg-white px-3 py-5"
+      className="min-h-[550px] bg-surface px-3 py-5"
       justifyContent="center"
       gap="32px"
       isFull

--- a/apps/web/src/app/trading-view/components/CoinInfo/index.tsx
+++ b/apps/web/src/app/trading-view/components/CoinInfo/index.tsx
@@ -132,7 +132,7 @@ const CoinInfo = ({ code }: Props) => {
             }
             className="gap-2"
           >
-            <MultilineText className="text-gray-400 max-sm:text-xs">
+            <MultilineText className="text-fg-muted max-sm:text-xs">
               {info.detail.content}
             </MultilineText>
           </SectionWithTitle>

--- a/apps/web/src/app/trading-view/components/Selector/BtcCoinSelector.tsx
+++ b/apps/web/src/app/trading-view/components/Selector/BtcCoinSelector.tsx
@@ -60,7 +60,7 @@ const BtcCoinSelector = ({ code }: BtcCoinSelectorProps) => {
         <Dropdown.Content>
           <Dropdown.Body
             className={cn(
-              'min-w-[180px] bg-white',
+              'min-w-[180px] bg-surface',
               'max-md:min-w-[150px] h-[300px] overflow-auto scroll-m-0',
             )}
           >

--- a/apps/web/src/app/trading-view/components/Selector/KrwCoinSelector.tsx
+++ b/apps/web/src/app/trading-view/components/Selector/KrwCoinSelector.tsx
@@ -60,7 +60,7 @@ const KrwCoinSelector = ({ code }: KrwCoinSelectorProps) => {
         <Dropdown.Content>
           <Dropdown.Body
             className={cn(
-              'min-w-[180px] bg-white',
+              'min-w-[180px] bg-surface',
               'max-md:min-w-[150px] h-[300px] overflow-auto scroll-m-0',
             )}
           >

--- a/apps/web/src/app/trading-view/components/Selector/UsdtCoinSelector.tsx
+++ b/apps/web/src/app/trading-view/components/Selector/UsdtCoinSelector.tsx
@@ -60,7 +60,7 @@ const UsdtCoinSelector = ({ code }: UsdtCoinSelectorProps) => {
         <Dropdown.Content>
           <Dropdown.Body
             className={cn(
-              'min-w-[180px] bg-white',
+              'min-w-[180px] bg-surface',
               'max-md:min-w-[150px] h-[300px] overflow-auto scroll-m-0',
             )}
           >

--- a/apps/web/src/app/trading-view/components/chart.tsx
+++ b/apps/web/src/app/trading-view/components/chart.tsx
@@ -105,7 +105,7 @@ export default function Chart({ code, type }: ChartProps) {
         )} ${code.toUpperCase()}/${type === 'BTC' ? 'BTC' : 'KRW'}`}
       />
       <Flex
-        className="bg-white p-3"
+        className="bg-surface p-3"
         isFull
         flexDirection="column"
         justifyContent="center"
@@ -207,7 +207,7 @@ export default function Chart({ code, type }: ChartProps) {
         </Flex>
       </Flex>
       <Spacing size="16px" type="vertical" />
-      <Flex className="mt-2 bg-white" isFull justifyContent="space-between">
+      <Flex className="mt-2 bg-surface" isFull justifyContent="space-between">
         <Tab.Group>
           {timeTabs.map(({ name, value }, idx) => (
             <Tab.Button

--- a/apps/web/src/app/trading-view/components/loading.tsx
+++ b/apps/web/src/app/trading-view/components/loading.tsx
@@ -9,7 +9,7 @@ interface LoadingProps extends PropsWithChildren {
 export default function Loading({ isLoading, children }: LoadingProps) {
   if (isLoading) {
     return (
-      <Flex isFull className="bg-white p-[4px]">
+      <Flex isFull className="bg-surface p-[4px]">
         <Skeleton width="100%" height="300px" />
       </Flex>
     );

--- a/apps/web/src/app/trend/components/News/NewsSkeleton.tsx
+++ b/apps/web/src/app/trend/components/News/NewsSkeleton.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 const NewsSkeleton = () => {
   return (
     <Flex
-      className="min-h-[500px] bg-white px-3 py-6"
+      className="min-h-[500px] bg-surface px-3 py-6"
       isFull
       flexDirection="column"
       gap="12px"

--- a/apps/web/src/app/trend/components/NewsList/index.tsx
+++ b/apps/web/src/app/trend/components/NewsList/index.tsx
@@ -34,7 +34,7 @@ function NewsList({ category }: NewsListProps) {
   if (list.length === 0) {
     return (
       <Flex
-        className="min-h-[500px] bg-white px-3 py-6"
+        className="min-h-[500px] bg-surface px-3 py-6"
         isFull
         flexDirection="column"
         gap="12px"
@@ -44,7 +44,7 @@ function NewsList({ category }: NewsListProps) {
 
   return (
     <Flex
-      className="min-h-[500px] bg-white px-3 py-6"
+      className="min-h-[500px] bg-surface px-3 py-6"
       isFull
       flexDirection="column"
       gap="12px"
@@ -69,7 +69,7 @@ function NewsList({ category }: NewsListProps) {
       </Flex>
       {rest.length > visibleCount && (
         <Button
-          className="mt-2 self-center rounded border border-gray-200 px-6 hover:bg-gray-50"
+          className="mt-2 self-center rounded border border-border px-6 hover:bg-gray-50"
           onClick={onClickMore}
           aria-label="뉴스 더보기"
         >

--- a/apps/web/src/app/trend/components/NewsList/index.tsx
+++ b/apps/web/src/app/trend/components/NewsList/index.tsx
@@ -69,7 +69,7 @@ function NewsList({ category }: NewsListProps) {
       </Flex>
       {rest.length > visibleCount && (
         <Button
-          className="mt-2 self-center rounded border border-border px-6 hover:bg-gray-50"
+          className="mt-2 self-center rounded border border-border px-6 hover:bg-gray-50 dark:hover:bg-neutral-800"
           onClick={onClickMore}
           aria-label="뉴스 더보기"
         >

--- a/apps/web/src/app/trend/components/Page.tsx
+++ b/apps/web/src/app/trend/components/Page.tsx
@@ -49,7 +49,7 @@ const TrendPage = ({ dailyAskVolumn, dailyBidVolumn }: TrendPageProps) => {
       gap="8px"
     >
       <Flex
-        className="bg-white p-3"
+        className="bg-surface p-3"
         alignItems="center"
         justifyContent="space-between"
         isFull
@@ -72,7 +72,7 @@ const TrendPage = ({ dailyAskVolumn, dailyBidVolumn }: TrendPageProps) => {
       <ErrorBoundary
         fallback={
           <Flex
-            className="my-auto min-h-[500px] bg-white"
+            className="my-auto min-h-[500px] bg-surface"
             isFull
             alignItems="center"
             justifyContent="center"
@@ -92,7 +92,7 @@ const TrendPage = ({ dailyAskVolumn, dailyBidVolumn }: TrendPageProps) => {
       <Flex className="max-md:!flex-col" gap="8px" isFull>
         <div
           className={cn(
-            'px-3 py-6 flex flex-col w-full h-auto bg-white flex-1',
+            'px-3 py-6 flex flex-col w-full h-auto bg-surface flex-1',
           )}
         >
           <div>
@@ -107,7 +107,7 @@ const TrendPage = ({ dailyAskVolumn, dailyBidVolumn }: TrendPageProps) => {
         </div>
         <div
           className={cn(
-            'px-3 py-6 flex flex-col w-full h-auto bg-white flex-1',
+            'px-3 py-6 flex flex-col w-full h-auto bg-surface flex-1',
           )}
         >
           <div>
@@ -122,7 +122,7 @@ const TrendPage = ({ dailyAskVolumn, dailyBidVolumn }: TrendPageProps) => {
         </div>
       </Flex>
       <Flex
-        className="min-h-[500px] bg-white px-3 py-6"
+        className="min-h-[500px] bg-surface px-3 py-6"
         isFull
         flexDirection="column"
       >

--- a/apps/web/src/components/common/ErrorBoundary.tsx
+++ b/apps/web/src/components/common/ErrorBoundary.tsx
@@ -25,7 +25,7 @@ class ErrorBoundary extends React.Component<PropsWithChildren, State> {
       // You can render any custom fallback UI
       return (
         <div className={cn('flex flex-col items-center justify-center', 'p-6')}>
-          <h1 className="text-[2rem] text-black">Something went wrong.</h1>
+          <h1 className="text-[2rem] text-fg">Something went wrong.</h1>
           <Button
             className={cn(
               'mt-4 bg-blue-600 border border-blue-600',
@@ -39,7 +39,7 @@ class ErrorBoundary extends React.Component<PropsWithChildren, State> {
             <div
               className={cn(
                 'w-full max-w-[492px] mt-6',
-                'bg-white text-xl rounded-lg shadow-[0_8px_24px_0_rgba(153,156,178,0.1)]',
+                'bg-surface text-xl rounded-lg shadow-[0_8px_24px_0_rgba(153,156,178,0.1)]',
               )}
             >
               <div
@@ -47,7 +47,7 @@ class ErrorBoundary extends React.Component<PropsWithChildren, State> {
                   'overflow-y-auto w-full min-h-[200px] max-h-[300px]',
                 )}
               >
-                <p className={cn('m-0 p-5 text-black')}>{error.stack}</p>
+                <p className={cn('m-0 p-5 text-fg')}>{error.stack}</p>
               </div>
             </div>
           )}

--- a/apps/web/src/components/common/ErrorMessage.tsx
+++ b/apps/web/src/components/common/ErrorMessage.tsx
@@ -13,7 +13,7 @@ const ErrorMessage = ({ title, description, className }: Props) => {
   return (
     <Flex
       className={cn(
-        'w-full rounded-md border border-gray-200 bg-white p-4',
+        'w-full rounded-md border border-border bg-surface p-4',
         className,
       )}
       flexDirection="column"

--- a/apps/web/src/components/shell/Exchange.tsx
+++ b/apps/web/src/components/shell/Exchange.tsx
@@ -12,14 +12,14 @@ const Exchange = ({ title, value, isLoading }: Props) => {
     <div
       className={cn(
         'flex flex-col gap-1 p-3',
-        'w-1/5 border border-[#d0d0d0] rounded-2xl',
-        'bg-white text-white whitespace-pre',
+        'w-1/5 border border-border rounded-2xl',
+        'bg-surface text-fg whitespace-pre',
         'max-md:w-auto max-md:rounded-none max-md:border-none max-md:px-2 max-md:py-1',
       )}
     >
       <h6
         className={cn(
-          'm-0 text-[14px] font-normal text-[#333333]',
+          'm-0 text-[14px] font-normal text-fg-muted',
           'max-md:text-[11px] max-md:w-min',
         )}
       >
@@ -28,7 +28,7 @@ const Exchange = ({ title, value, isLoading }: Props) => {
       {isLoading ? (
         <Skeleton width="100%" height={27} borderRadius="4px" />
       ) : (
-        <p className={cn('m-0 text-black', 'max-md:text-[10px]')}>{value}</p>
+        <p className={cn('m-0 text-fg', 'max-md:text-[10px]')}>{value}</p>
       )}
     </div>
   );

--- a/apps/web/src/components/shell/ExchangeList/index.tsx
+++ b/apps/web/src/components/shell/ExchangeList/index.tsx
@@ -14,7 +14,7 @@ function ExchangeList() {
         className={cn(
           'flex gap-1 my-2 mx-0',
           'max-md:w-full max-md:gap-0 max-md:my-1',
-          'max-md:border max-md:border-[#d0d0d0] max-md:bg-white',
+          'max-md:border max-md:border-border max-md:bg-surface',
           'max-sm:hidden max-sm:py-0 max-sm:px-1',
         )}
       >
@@ -48,7 +48,7 @@ function ExchangeList() {
         className={cn(
           'hidden gap-1 my-2 mx-0',
           'max-md:w-full max-md:gap-0 max-md:my-1',
-          'max-md:border max-md:border-[#d0d0d0] max-md:bg-white',
+          'max-md:border max-md:border-border max-md:bg-surface',
           'max-sm:flex max-sm:py-0 max-sm:px-1',
         )}
       >

--- a/apps/web/src/components/shell/FearGreed/FearGreed.server.tsx
+++ b/apps/web/src/components/shell/FearGreed/FearGreed.server.tsx
@@ -8,7 +8,7 @@ export default function FearGreedServer() {
     <section
       className={cn(
         'flex justify-between items-center',
-        'p-3 mt-2 bg-white border border-[#d0d0d0] font-semibold',
+        'p-3 mt-2 bg-surface border border-border font-semibold',
         'max-md:p-2 max-md:mt-0 max-md:text-sm',
         'max-sm:text-[11px]',
       )}

--- a/apps/web/src/components/shell/Layout/Footer.tsx
+++ b/apps/web/src/components/shell/Layout/Footer.tsx
@@ -1,6 +1,6 @@
 const Footer = () => {
   return (
-    <footer className="w-full bg-white">
+    <footer className="w-full bg-surface">
       <div className="w-full max-w-[1410px] p-3">Footer</div>
     </footer>
   );

--- a/apps/web/src/components/shell/Layout/Header.tsx
+++ b/apps/web/src/components/shell/Layout/Header.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import ThemeToggle from '@/components/shell/ThemeToggle';
 import Text from '@/components/ui/Text';
 import { cn } from '@/lib/utils';
 import { palette } from '@/styles/variables';
@@ -39,12 +40,13 @@ const Header = () => {
             </div>
           </Link>
         </div>
-        <div>
+        <div className={cn('flex items-center gap-2')}>
           <Link href="/trend">
             <Text fontSize="14px" color={palette.white}>
               코인동향
             </Text>
           </Link>
+          <ThemeToggle />
         </div>
       </nav>
     </div>

--- a/apps/web/src/components/shell/ThemeToggle.tsx
+++ b/apps/web/src/components/shell/ThemeToggle.tsx
@@ -40,17 +40,15 @@ const MoonIcon = () => (
 const ThemeToggle = () => {
   const theme = useThemeStore((state) => state.theme);
   const toggleTheme = useThemeStore((state) => state.toggleTheme);
-  const hydrate = useThemeStore((state) => state.hydrate);
   const [mounted, setMounted] = useState(false);
 
-  // Sync the store with the theme the pre-paint inline script already applied.
+  // The store initializes from the DOM on the client, but SSR/first client
+  // render is always 'light'; render a same-size placeholder until mounted to
+  // avoid a hydration mismatch and an icon flip / layout shift.
   useEffect(() => {
-    hydrate();
     setMounted(true);
-  }, [hydrate]);
+  }, []);
 
-  // Until mounted, the store still holds its default ('light'); render a
-  // same-size placeholder to avoid an icon flip / layout shift on hydration.
   if (!mounted) {
     return <div className={cn('w-8 h-8', 'max-md:w-7 max-md:h-7')} />;
   }

--- a/apps/web/src/components/shell/ThemeToggle.tsx
+++ b/apps/web/src/components/shell/ThemeToggle.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect } from 'react';
+import { cn } from '@/lib/utils';
+import { useThemeStore } from '@/store/theme';
+
+const SunIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);
+
+const ThemeToggle = () => {
+  const theme = useThemeStore((state) => state.theme);
+  const toggleTheme = useThemeStore((state) => state.toggleTheme);
+  const hydrate = useThemeStore((state) => state.hydrate);
+
+  // Sync the store with the theme the pre-paint inline script already applied.
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? '라이트 모드로 전환' : '다크 모드로 전환'}
+      title={isDark ? '라이트 모드로 전환' : '다크 모드로 전환'}
+      className={cn(
+        'flex items-center justify-center',
+        'w-8 h-8 rounded-md text-white',
+        'hover:bg-white/10 transition-colors',
+        'max-md:w-7 max-md:h-7',
+      )}
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/apps/web/src/components/shell/ThemeToggle.tsx
+++ b/apps/web/src/components/shell/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useThemeStore } from '@/store/theme';
 
@@ -41,11 +41,19 @@ const ThemeToggle = () => {
   const theme = useThemeStore((state) => state.theme);
   const toggleTheme = useThemeStore((state) => state.toggleTheme);
   const hydrate = useThemeStore((state) => state.hydrate);
+  const [mounted, setMounted] = useState(false);
 
   // Sync the store with the theme the pre-paint inline script already applied.
   useEffect(() => {
     hydrate();
+    setMounted(true);
   }, [hydrate]);
+
+  // Until mounted, the store still holds its default ('light'); render a
+  // same-size placeholder to avoid an icon flip / layout shift on hydration.
+  if (!mounted) {
+    return <div className={cn('w-8 h-8', 'max-md:w-7 max-md:h-7')} />;
+  }
 
   const isDark = theme === 'dark';
 

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -13,7 +13,7 @@ const Button = ({
   return (
     <button
       className={cn(
-        'bg-white text-black p-2 w-auto',
+        'bg-surface text-fg p-2 w-auto',
         'cursor-pointer disabled:cursor-not-allowed',
         className,
       )}

--- a/apps/web/src/components/ui/Tab/Group.tsx
+++ b/apps/web/src/components/ui/Tab/Group.tsx
@@ -5,7 +5,7 @@ const Group = ({ children, className }: ComponentProps<'div'>) => {
   return (
     <div
       className={cn(
-        'flex items-center bg-white relative [&_*]:flex-1',
+        'flex items-center bg-surface relative [&_*]:flex-1',
         className,
       )}
     >

--- a/apps/web/src/components/ui/Table/Cell.tsx
+++ b/apps/web/src/components/ui/Table/Cell.tsx
@@ -13,7 +13,7 @@ const Cell = ({ children, color, width }: CellProps) => {
         'text-[var(--color)] w-[var(--width)]',
       )}
       style={{
-        '--color': color ?? '#000000',
+        '--color': color ?? 'var(--color-fg)',
         '--width': width ?? '30%',
       }}
     >

--- a/apps/web/src/components/ui/Table/Skeleton.tsx
+++ b/apps/web/src/components/ui/Table/Skeleton.tsx
@@ -2,7 +2,7 @@ import Skeleton from '@/components/ui/Skeleton';
 
 const TableSkeleton = () => {
   return (
-    <div className="mt-3 w-full bg-white p-2">
+    <div className="mt-3 w-full bg-surface p-2">
       <Skeleton width="100%" height={52} borderRadius="8px" />
       <Skeleton
         width="100%"

--- a/apps/web/src/components/ui/Table/index.tsx
+++ b/apps/web/src/components/ui/Table/index.tsx
@@ -10,10 +10,8 @@ type Props = {
 
 const Table = ({ header, body }: Props) => {
   return (
-    <div className="w-full rounded-lg border border-gray-200 bg-white">
-      <div className="flex items-center border-b border-b-gray-200">
-        {header}
-      </div>
+    <div className="w-full rounded-lg border border-border bg-surface">
+      <div className="flex items-center border-b border-b-border">{header}</div>
       <div>{body}</div>
     </div>
   );

--- a/apps/web/src/components/ui/Text.tsx
+++ b/apps/web/src/components/ui/Text.tsx
@@ -20,7 +20,7 @@ const Text = ({
       style={{
         fontSize: fontSize ?? '16px',
         fontWeight: fontWeight ?? 400,
-        color: color ?? 'black',
+        color: color ?? 'var(--color-fg)',
       }}
     >
       {children}

--- a/apps/web/src/hooks/queries/useTickersData.ts
+++ b/apps/web/src/hooks/queries/useTickersData.ts
@@ -27,6 +27,7 @@ const useTickerData = ({
 }: UseTickerDataProps) => {
   const [selectedType, setSelectedType] = useState<string | null>(null);
   const [sortType, setSortType] = useState(INIT_SORT_TYPE);
+  const [keyword, setKeyword] = useState('');
 
   const { type } = useCoinStore();
   const { combineTickers } = useCryptoSocketStore();
@@ -79,9 +80,20 @@ const useTickerData = ({
     );
   }, [data, selectedType, sortType]);
 
+  const filteredData = useMemo(() => {
+    if (!sortedData) return undefined;
+    const trimmed = keyword.trim().toLowerCase();
+    if (!trimmed) return sortedData;
+    return sortedData.filter(({ symbol }) =>
+      symbol.toLowerCase().includes(trimmed),
+    );
+  }, [sortedData, keyword]);
+
   return {
-    data: sortedData,
+    data: filteredData,
     handleSort,
+    keyword,
+    setKeyword,
     ...rest,
   };
 };

--- a/apps/web/src/hooks/queries/useTickersData.ts
+++ b/apps/web/src/hooks/queries/useTickersData.ts
@@ -85,7 +85,7 @@ const useTickerData = ({
     const trimmed = keyword.trim().toLowerCase();
     if (!trimmed) return sortedData;
     return sortedData.filter(({ symbol }) =>
-      symbol.toLowerCase().includes(trimmed),
+      symbol?.toLowerCase().includes(trimmed),
     );
   }, [sortedData, keyword]);
 

--- a/apps/web/src/hooks/trading-view/useUpbitDataFeed.ts
+++ b/apps/web/src/hooks/trading-view/useUpbitDataFeed.ts
@@ -15,6 +15,7 @@ import { useUpbitSeriesData } from 'hooks/queries/useUpbitCandles';
 import { getUpbitCandles } from '@/api';
 import { getCandleKey, getUnitKey } from '@/lib/trading-view/utils';
 import { useCryptoSocketStore } from '@/store/socket';
+import { useThemeStore } from '@/store/theme';
 import { palette } from '@/styles/variables';
 import { TickerType } from '@/types/Coin';
 
@@ -36,12 +37,13 @@ const useUpbitDataFeed = ({
   const isFetchingRef = useRef(false);
   const priceSymbol = type === 'BTC' ? 'BTC' : 'KRW';
 
+  const theme = useThemeStore((state) => state.theme);
   const colors = useMemo(
-    () => ({
-      backgroundColor: 'white',
-      textColor: 'black',
-    }),
-    [],
+    () =>
+      theme === 'dark'
+        ? { backgroundColor: '#191b21', textColor: '#e6e6e6' } // --color-surface / --color-fg (dark)
+        : { backgroundColor: '#ffffff', textColor: '#000000' }, // --color-surface / --color-fg (light)
+    [theme],
   );
 
   const seriesDataMap = useUpbitSeriesData({

--- a/apps/web/src/hooks/trading-view/useUpbitDataFeed.ts
+++ b/apps/web/src/hooks/trading-view/useUpbitDataFeed.ts
@@ -192,7 +192,20 @@ const useUpbitDataFeed = ({
       chartRef.current = null;
       seriesRef.current = null;
     };
-  }, [containerRef, colors]);
+    // colors intentionally omitted: theme changes are applied via applyOptions
+    // below so the chart is not recreated (avoids flicker / losing zoom state).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerRef]);
+
+  // ✅ 테마 변경 시 차트를 재생성하지 않고 색상 옵션만 갱신
+  useEffect(() => {
+    chartRef.current?.applyOptions({
+      layout: {
+        background: { type: ColorType.Solid, color: colors.backgroundColor },
+        textColor: colors.textColor,
+      },
+    });
+  }, [colors]);
 
   // ✅ 단위가 바뀌었을 때 데이터 교체
   useEffect(() => {

--- a/apps/web/src/store/theme.ts
+++ b/apps/web/src/store/theme.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+// zustand
+
+export type Theme = 'light' | 'dark';
+
+type State = {
+  theme: Theme;
+};
+
+type Action = {
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  hydrate: () => void;
+};
+
+const applyTheme = (theme: Theme) => {
+  if (typeof document === 'undefined') return;
+
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.style.colorScheme = theme;
+
+  try {
+    localStorage.setItem('theme', theme);
+  } catch {
+    // ignore storage errors (e.g. private mode)
+  }
+};
+
+export const useThemeStore = create<State & Action>((set, get) => ({
+  // default matches the pre-paint inline script's fallback (light);
+  // real value is synced from the DOM via hydrate() on mount.
+  theme: 'light',
+  setTheme: (theme: Theme) => {
+    applyTheme(theme);
+    set({ theme });
+  },
+  toggleTheme: () => {
+    const next: Theme = get().theme === 'dark' ? 'light' : 'dark';
+    applyTheme(next);
+    set({ theme: next });
+  },
+  hydrate: () => {
+    if (typeof document === 'undefined') return;
+    const theme: Theme = document.documentElement.classList.contains('dark')
+      ? 'dark'
+      : 'light';
+    set({ theme });
+  },
+}));

--- a/apps/web/src/store/theme.ts
+++ b/apps/web/src/store/theme.ts
@@ -11,7 +11,6 @@ type State = {
 type Action = {
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
-  hydrate: () => void;
 };
 
 const applyTheme = (theme: Theme) => {
@@ -28,10 +27,19 @@ const applyTheme = (theme: Theme) => {
   }
 };
 
+// Read the theme the pre-paint inline script (in layout.tsx) already applied to
+// <html>. On the client the store initializes from the real DOM state, so theme
+// sync does not depend on any component (e.g. ThemeToggle) being mounted. On the
+// server there is no DOM, so it falls back to 'light' (matched by the mounted
+// guard in consumers to avoid a hydration mismatch).
+const getInitialTheme = (): Theme =>
+  typeof document !== 'undefined' &&
+  document.documentElement.classList.contains('dark')
+    ? 'dark'
+    : 'light';
+
 export const useThemeStore = create<State & Action>((set, get) => ({
-  // default matches the pre-paint inline script's fallback (light);
-  // real value is synced from the DOM via hydrate() on mount.
-  theme: 'light',
+  theme: getInitialTheme(),
   setTheme: (theme: Theme) => {
     applyTheme(theme);
     set({ theme });
@@ -40,12 +48,5 @@ export const useThemeStore = create<State & Action>((set, get) => ({
     const next: Theme = get().theme === 'dark' ? 'light' : 'dark';
     applyTheme(next);
     set({ theme: next });
-  },
-  hydrate: () => {
-    if (typeof document === 'undefined') return;
-    const theme: Theme = document.documentElement.classList.contains('dark')
-      ? 'dark'
-      : 'light';
-    set({ theme });
   },
 }));

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -1,3 +1,25 @@
+:root {
+  color-scheme: light;
+  --color-bg: #ededed;
+  --color-surface: #ffffff;
+  --color-fg: #000000;
+  --color-fg-muted: #999999;
+  --color-border: #d0d0d0;
+  --color-up: #ef5350;
+  --color-down: #0062df;
+}
+
+.dark {
+  color-scheme: dark;
+  --color-bg: #0e0f13;
+  --color-surface: #191b21;
+  --color-fg: #e6e6e6;
+  --color-fg-muted: #8a8f99;
+  --color-border: #2b2e37;
+  --color-up: #ff5b57;
+  --color-down: #4b8bff;
+}
+
 * {
   box-sizing: border-box;
   line-height: 1.5;
@@ -17,7 +39,8 @@ body,
 }
 
 body {
-  background-color: #ededed;
+  background-color: var(--color-bg);
+  color: var(--color-fg);
 }
 
 a {

--- a/apps/web/src/styles/variables.ts
+++ b/apps/web/src/styles/variables.ts
@@ -58,9 +58,12 @@ export const spacing: Spacing = Object.keys(spacingNumber).reduce(
 
 /*Palette*/
 export const palette = {
+  // Concrete colors: also consumed by Lightweight Charts (canvas), where CSS
+  // variables do not resolve. Up/down semantics are identical in both themes.
   red: '#ef5350',
   blue: '#0062df',
-  black: '#000000',
+  // Text tokens (DOM only) — theme-aware via CSS variables.
+  black: 'var(--color-fg)',
   white: '#ffffff',
-  gray: '#999',
+  gray: 'var(--color-fg-muted)',
 };

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -3,6 +3,7 @@ import type { Config } from 'tailwindcss';
 const plugin = require('tailwindcss/plugin');
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -18,6 +19,15 @@ const config: Config = {
       xl: '1265px',
     },
     extend: {
+      colors: {
+        bg: 'var(--color-bg)',
+        surface: 'var(--color-surface)',
+        fg: 'var(--color-fg)',
+        'fg-muted': 'var(--color-fg-muted)',
+        border: 'var(--color-border)',
+        up: 'var(--color-up)',
+        down: 'var(--color-down)',
+      },
       keyframes: {
         skeleton: {
           from: {


### PR DESCRIPTION
# 요약

메인 시세표에 심볼 기준 코인 검색 필터를 추가하고, 시스템 설정을 따르는 다크모드(라이트/다크 토글)를 도입합니다.

## 주요 작업:

- **다크모드 도입**
  - 시맨틱 CSS 변수 토큰 레이어(`--color-bg/surface/fg/fg-muted/border/up/down`)를 `base.css`에 라이트·다크 값으로 정의하고, 흩어져 있던 리터럴 색상을 단일 소스로 통합
  - Tailwind `darkMode: 'class'` 활성화 + 토큰을 유틸리티 클래스로 매핑(`bg-surface`, `text-fg`, `border-border` 등)
  - `layout.tsx`에 페인트 전 인라인 스크립트 추가 → 최초 방문 시 OS 색상 설정을 따르고, 저장된 선택을 복원하며 화면 깜빡임(FOUC) 방지
  - Zustand 테마 스토어(`store/theme.ts`)와 헤더 토글(`ThemeToggle`) 추가, 선택값을 localStorage에 저장
- **코인 검색 필터**
  - `useTickersData`에 `keyword` 상태와 심볼 기준(대소문자 무관) 필터 추가, `setKeyword` 노출
  - 메인 시세표 상단에 검색 입력창 추가, `react-use`의 `useDebounce`로 디바운스 처리

## 기타 작업:

- 컴포넌트 전반의 하드코딩 색상을 시맨틱 토큰으로 마이그레이션(`bg-white`→`bg-surface`, `text-black`→`text-fg`, `border-[#d0d0d0]`/`border-gray-200`→`border-border` 등)
- `CoinTable`에서 로딩 상태와 검색 결과 없음을 구분 → 로딩 중에는 스켈레톤, 검색 결과가 없을 때는 안내 메시지를 표시하여 결과 0건 시 스켈레톤이 무한 노출되던 문제 수정
- `<html lang>`을 `en`에서 `ko`로 정정

## 고민사항 및 추후 고려사항:

- **검색 범위**: 이번에는 심볼만 검색합니다. 한글명 검색은 현재 `lib/coin.ts`가 `korean_name`을 버리고 있어 데이터 파이프라인 확장이 필요하므로 후속 작업으로 남겨둡니다.
- **차트 색상**: Lightweight Charts 캔버스는 CSS 변수가 적용되지 않아 테마별 concrete hex 값을 사용합니다. 토큰 값과 수동으로 맞춰야 하므로 토큰 변경 시 `useUpbitDataFeed.ts`도 함께 갱신이 필요합니다.
- **다크 팔레트**: 다크 토큰 값은 초기 기준치로, 실제 화면 대비/가독성 확인 후 미세 조정이 필요할 수 있습니다.