### PR TITLE
feat(web): add per-market watchlist page

### DIFF
--- a/apps/web/src/app/(main)/components/CoinTable.tsx
+++ b/apps/web/src/app/(main)/components/CoinTable.tsx
@@ -4,6 +4,7 @@ import { Icon } from 'ownui-system';
 import { useMedia } from 'react-use';
 import { faStar as UnLiked } from '@fortawesome/free-regular-svg-icons';
 import { faStar as Liked } from '@fortawesome/free-solid-svg-icons';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Button from '@/components/ui/Button';
 import Spacing from '@/components/ui/Spacing';
@@ -22,12 +23,32 @@ import { TickerType } from '@/types/Coin';
 
 type Props = {
   coinList: CombinedTickers[];
-  handleSort: (type: Sort) => () => void;
+  handleSort?: (type: Sort) => () => void;
   isLoading?: boolean;
+  // When provided, the leading star toggle is replaced with a remove (x) button
+  // and the favorite-sorting is skipped — used by the watchlist group cards,
+  // where rows come pre-scoped to a group and are removed, not favorited.
+  onRemove?: (symbol: string) => void;
+  emptyMessage?: string;
+  // Pin the table to a specific market instead of the global coin-store type
+  // (the watchlist shows KRW/BTC/USDT cards side by side, each with its own).
+  marketType?: TickerType;
+  // Drop the outer border so it can render inside another bordered card.
+  bare?: boolean;
 };
 
-const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
-  const { type } = useCoinStore();
+const CoinTable = ({
+  coinList,
+  handleSort,
+  isLoading = false,
+  onRemove,
+  emptyMessage = '검색 결과가 없습니다.',
+  marketType,
+  bare = false,
+}: Props) => {
+  const { type: storeType } = useCoinStore();
+  const type = marketType ?? storeType;
+  const isRemoveVariant = !!onRemove;
   const isSmDown = useMedia(getBreakpointQuery(breakpoints.down('sm')), false);
 
   const { value: krwFavList, updateValue: updateKrwFavList } = useLocalStorage<
@@ -78,6 +99,11 @@ const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
   };
 
   const filteredCointList = useMemo(() => {
+    if (isRemoveVariant) {
+      // Watchlist group card: keep the caller-provided order as-is.
+      return coinList.filter((data) => data.symbol !== 'BTC');
+    }
+
     return [
       ...coinList.filter(
         (data) => data.symbol !== 'BTC' && isFavSymbol(data.symbol),
@@ -86,17 +112,20 @@ const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
         (data) => data.symbol !== 'BTC' && !isFavSymbol(data.symbol),
       ),
     ];
-  }, [coinList, isFavSymbol]);
+  }, [coinList, isFavSymbol, isRemoveVariant]);
 
   return (
     <Table
+      bare={bare}
       header={
         <>
           {TABLE_HEADERS.map((name, idx) => (
             <Table.Header
               key={name}
               name={
-                idx > 0 && idx < 3
+                // The watchlist card already shows the market as a badge, so
+                // drop the redundant (₩/BTC/USDT) suffix there to save space.
+                idx > 0 && idx < 3 && !isRemoveVariant
                   ? `${name}(${
                       MARKET_SYMBOLS[idx === 1 ? 'upbit' : 'binance'][
                         type as TickerType
@@ -104,9 +133,13 @@ const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
                     })`
                   : name
               }
-              right={<Icon name="ArrowUpDown" size={14} />}
+              right={
+                isRemoveVariant ? undefined : (
+                  <Icon name="ArrowUpDown" size={14} />
+                )
+              }
               width="25%"
-              onClick={handleSort(sortColumn[idx])}
+              onClick={handleSort ? handleSort(sortColumn[idx]) : undefined}
             />
           ))}
         </>
@@ -122,23 +155,42 @@ const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
                 'text-center text-sm text-fg-muted',
               )}
             >
-              검색 결과가 없습니다.
+              {emptyMessage}
             </div>
           )
         ) : (
           <>
             {filteredCointList.map((data) => (
-              <Table.Row key={data.symbol}>
+              <Table.Row
+                key={data.symbol}
+                className={cn(
+                  isRemoveVariant &&
+                    'py-1.5 border-b border-border/70 last:border-b-0 hover:bg-bg transition-colors',
+                )}
+              >
                 <Table.Cell>
                   <div
                     className={cn('flex items-center gap-2', 'max-sm:gap-0.5')}
                   >
-                    <Button className="p-0" onClick={toggleFav(data.symbol)}>
-                      <FontAwesomeIcon
-                        className="text-[#e2be1b]"
-                        icon={isFavSymbol(data.symbol) ? Liked : UnLiked}
-                      />
-                    </Button>
+                    {isRemoveVariant ? (
+                      <Button
+                        className={cn(
+                          'p-0 bg-transparent text-fg-muted transition-colors',
+                          'hover:text-[#ef5350]',
+                        )}
+                        aria-label={`${data.symbol} 관심목록에서 제거`}
+                        onClick={() => onRemove?.(data.symbol)}
+                      >
+                        <FontAwesomeIcon icon={faXmark} />
+                      </Button>
+                    ) : (
+                      <Button className="p-0" onClick={toggleFav(data.symbol)}>
+                        <FontAwesomeIcon
+                          className="text-[#e2be1b]"
+                          icon={isFavSymbol(data.symbol) ? Liked : UnLiked}
+                        />
+                      </Button>
+                    )}
                     <Spacing size="4px" />
                     <Link
                       className={cn('flex items-center gap-1 cursor-pointer')}
@@ -153,7 +205,12 @@ const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
                           height={20}
                         />
                       </picture>
-                      <Text fontSize={isSmDown ? 14 : 16}>{data.symbol}</Text>
+                      <Text
+                        fontSize={isRemoveVariant ? 13 : isSmDown ? 14 : 16}
+                        fontWeight={isRemoveVariant ? 600 : undefined}
+                      >
+                        {data.symbol}
+                      </Text>
                     </Link>
                   </div>
                 </Table.Cell>
@@ -195,7 +252,12 @@ const CoinTable = ({ coinList, handleSort, isLoading = false }: Props) => {
                   }
                 >
                   <div className={cn('flex flex-col')}>
-                    <p className="m-0">{setComma(data?.per ?? 0)}%</p>
+                    <p
+                      className={cn('m-0', isRemoveVariant && 'font-semibold')}
+                    >
+                      {isRemoveVariant && (data?.per ?? 0) > 0 ? '+' : ''}
+                      {setComma(data?.per ?? 0)}%
+                    </p>
                   </div>
                 </Table.Cell>
               </Table.Row>

--- a/apps/web/src/app/watchlist/components/AddCoinModal/index.tsx
+++ b/apps/web/src/app/watchlist/components/AddCoinModal/index.tsx
@@ -100,7 +100,9 @@ const AddCoinModal = ({
           </div>
 
           <ul
-            className={cn('mt-3 px-2 pb-2 overflow-y-auto flex-1 max-h-[320px]')}
+            className={cn(
+              'mt-3 px-2 pb-2 overflow-y-auto flex-1 max-h-[320px]',
+            )}
           >
             {filtered.length === 0 ? (
               <li

--- a/apps/web/src/app/watchlist/components/AddCoinModal/index.tsx
+++ b/apps/web/src/app/watchlist/components/AddCoinModal/index.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Icon, Modal, ModalContent } from 'ownui-system';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { getCoinSymbolImage } from '@/lib/coin';
+import { cn } from '@/lib/utils';
+import { Coin } from '@/types/Coin';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  groupName: string;
+  coinData: Coin[];
+  selectedSymbols: string[];
+  onToggle: (symbol: string, checked: boolean) => void;
+};
+
+const AddCoinModal = ({
+  isOpen,
+  onClose,
+  groupName,
+  coinData,
+  selectedSymbols,
+  onToggle,
+}: Props) => {
+  const [keyword, setKeyword] = useState('');
+
+  const selectedSet = useMemo(
+    () => new Set(selectedSymbols),
+    [selectedSymbols],
+  );
+
+  const filtered = useMemo(() => {
+    const trimmed = keyword.trim().toLowerCase();
+    const list = coinData.filter(({ name }) => name !== 'BTC');
+    if (!trimmed) return list;
+    return list.filter(({ name }) => name.toLowerCase().includes(trimmed));
+  }, [coinData, keyword]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} onOpenChange={() => onClose()}>
+      <ModalContent className="!h-auto !w-auto !overflow-visible !bg-transparent !shadow-none">
+        <div
+          className={cn(
+            'w-[380px] max-w-[92vw] rounded-2xl',
+            'bg-surface text-fg border border-border shadow-xl',
+            'flex flex-col max-h-[70vh]',
+          )}
+        >
+          <div
+            className={cn('flex items-start justify-between', 'px-5 pt-5 pb-3')}
+          >
+            <div className={cn('min-w-0')}>
+              <h2 className={cn('m-0 text-lg font-bold')}>종목 추가</h2>
+              <p className={cn('m-0 mt-0.5 text-sm text-fg-muted truncate')}>
+                {groupName}
+              </p>
+            </div>
+            <Button
+              className={cn(
+                'flex items-center justify-center w-8 h-8 rounded-md',
+                'text-fg-muted hover:bg-bg hover:text-fg transition-colors',
+              )}
+              aria-label="닫기"
+              onClick={onClose}
+            >
+              <FontAwesomeIcon icon={faXmark} />
+            </Button>
+          </div>
+
+          <div className={cn('px-5')}>
+            <div className={cn('relative')}>
+              <span
+                className={cn(
+                  'absolute left-3 top-1/2 -translate-y-1/2 text-fg-muted',
+                  'pointer-events-none',
+                )}
+              >
+                <Icon name="Search" size={16} />
+              </span>
+              <Input
+                autoFocus
+                type="search"
+                value={keyword}
+                onChange={(e) => setKeyword(e.target.value)}
+                placeholder="코인 검색 (예: BTC)"
+                aria-label="코인 검색"
+                className={cn(
+                  'w-full rounded-lg pl-9 pr-3 py-2.5 text-sm',
+                  'bg-bg text-fg border border-border',
+                  'placeholder:text-fg-muted',
+                  'focus:outline-none focus:ring-2 focus:ring-[#f8b64c]/60 focus:border-[#f8b64c]',
+                )}
+              />
+            </div>
+          </div>
+
+          <ul
+            className={cn('mt-3 px-2 pb-2 overflow-y-auto flex-1 max-h-[320px]')}
+          >
+            {filtered.length === 0 ? (
+              <li
+                className={cn(
+                  'flex flex-col items-center justify-center gap-2 py-12',
+                  'text-fg-muted',
+                )}
+              >
+                <Icon name="SearchX" size={22} />
+                <span className={cn('text-sm')}>검색 결과가 없습니다.</span>
+              </li>
+            ) : (
+              filtered.map(({ name }) => {
+                const checked = selectedSet.has(name);
+                return (
+                  <li key={name}>
+                    <label
+                      className={cn(
+                        'flex items-center gap-3 px-3 py-2.5 rounded-lg',
+                        'cursor-pointer transition-colors',
+                        checked ? 'bg-[#f8b64c]/10' : 'hover:bg-bg',
+                      )}
+                    >
+                      <picture>
+                        <img
+                          className="w-6 min-w-5 rounded-full"
+                          alt={name}
+                          src={getCoinSymbolImage(name)}
+                          width={24}
+                          height={24}
+                        />
+                      </picture>
+                      <span
+                        className={cn(
+                          'flex-1 text-sm',
+                          checked && 'font-semibold',
+                        )}
+                      >
+                        {name}
+                      </span>
+                      <span
+                        className={cn(
+                          'flex items-center justify-center w-5 h-5 rounded-md border transition-colors',
+                          checked
+                            ? 'bg-[#f8b64c] border-[#f8b64c] text-black'
+                            : 'border-border',
+                        )}
+                      >
+                        {checked && <Icon name="Check" size={14} />}
+                      </span>
+                      <input
+                        type="checkbox"
+                        className="sr-only"
+                        checked={checked}
+                        onChange={(e) => onToggle(name, e.target.checked)}
+                      />
+                    </label>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+
+          <div
+            className={cn(
+              'flex items-center justify-between gap-3',
+              'px-5 py-3 border-t border-border',
+            )}
+          >
+            <span className={cn('text-sm text-fg-muted')}>
+              <span className={cn('font-semibold text-fg')}>
+                {selectedSymbols.length}
+              </span>
+              개 선택됨
+            </span>
+            <Button
+              className={cn(
+                'px-4 py-2 rounded-lg text-sm font-semibold',
+                'bg-[#f8b64c] text-black hover:opacity-90 transition-opacity',
+              )}
+              onClick={onClose}
+            >
+              완료
+            </Button>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default AddCoinModal;

--- a/apps/web/src/app/watchlist/components/AddCoinModal/index.tsx
+++ b/apps/web/src/app/watchlist/components/AddCoinModal/index.tsx
@@ -36,7 +36,7 @@ const AddCoinModal = ({
 
   const filtered = useMemo(() => {
     const trimmed = keyword.trim().toLowerCase();
-    const list = coinData.filter(({ name }) => name !== 'BTC');
+    const list = (coinData || []).filter(({ name }) => name !== 'BTC');
     if (!trimmed) return list;
     return list.filter(({ name }) => name.toLowerCase().includes(trimmed));
   }, [coinData, keyword]);

--- a/apps/web/src/app/watchlist/components/GroupCard/index.tsx
+++ b/apps/web/src/app/watchlist/components/GroupCard/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { type WatchGroup } from '@/store/watchlist';
+import MarketCard from '../MarketCard';
+import type { MarketView } from '../Page';
+
+type Props = {
+  group: WatchGroup;
+  markets: MarketView[];
+};
+
+const GroupCard = ({ group, markets }: Props) => {
+  return (
+    <div
+      className={cn('grid gap-4 items-start', 'sm:grid-cols-2 xl:grid-cols-3')}
+    >
+      {markets.map((market) => (
+        <MarketCard
+          key={market.key}
+          groupId={group.id}
+          groupName={group.name}
+          market={market}
+          symbols={group.markets[market.key]}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default GroupCard;

--- a/apps/web/src/app/watchlist/components/GroupFormModal/index.tsx
+++ b/apps/web/src/app/watchlist/components/GroupFormModal/index.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Modal, ModalContent } from 'ownui-system';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+  title: string;
+  submitLabel: string;
+  initialName?: string;
+};
+
+const GroupFormModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  title,
+  submitLabel,
+  initialName = '',
+}: Props) => {
+  const [name, setName] = useState(initialName);
+
+  useEffect(() => {
+    if (isOpen) setName(initialName);
+  }, [isOpen, initialName]);
+
+  const handleSubmit = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} onOpenChange={() => onClose()}>
+      <ModalContent className="!h-auto !w-auto !overflow-visible !bg-transparent !shadow-none">
+        <div
+          className={cn(
+            'w-[340px] max-w-[90vw] p-6 rounded-2xl',
+            'bg-surface text-fg border border-border shadow-xl',
+          )}
+        >
+          <h2 className={cn('m-0 mb-1 text-lg font-bold')}>{title}</h2>
+          <p className={cn('m-0 mb-4 text-sm text-fg-muted')}>
+            관심 종목을 묶어서 관리할 그룹 이름을 입력하세요.
+          </p>
+          <Input
+            autoFocus
+            maxLength={20}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSubmit();
+            }}
+            placeholder="예: 단기 트레이딩"
+            aria-label="그룹 이름"
+            className={cn(
+              'w-full rounded-lg px-3 py-2.5 text-sm',
+              'bg-bg text-fg border border-border',
+              'placeholder:text-fg-muted',
+              'focus:outline-none focus:ring-2 focus:ring-[#f8b64c]/60 focus:border-[#f8b64c]',
+            )}
+          />
+          <div className={cn('flex justify-end gap-2 mt-6')}>
+            <Button
+              className={cn(
+                'px-4 py-2 rounded-lg text-sm font-medium',
+                'text-fg-muted hover:bg-bg transition-colors',
+              )}
+              onClick={onClose}
+            >
+              취소
+            </Button>
+            <Button
+              className={cn(
+                'px-4 py-2 rounded-lg text-sm font-semibold',
+                'bg-[#f8b64c] text-black transition-opacity',
+                'hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed',
+              )}
+              disabled={!name.trim()}
+              onClick={handleSubmit}
+            >
+              {submitLabel}
+            </Button>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default GroupFormModal;

--- a/apps/web/src/app/watchlist/components/MarketCard/index.tsx
+++ b/apps/web/src/app/watchlist/components/MarketCard/index.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Icon } from 'ownui-system';
+import Button from '@/components/ui/Button';
+import { cn } from '@/lib/utils';
+import { CombinedTickers } from '@/store/socket';
+import { useWatchlistStore } from '@/store/watchlist';
+import CoinTable from '../../../(main)/components/CoinTable';
+import AddCoinModal from '../AddCoinModal';
+import type { MarketView } from '../Page';
+
+type Props = {
+  groupId: string;
+  groupName: string;
+  market: MarketView;
+  symbols: string[];
+};
+
+const MarketCard = ({ groupId, groupName, market, symbols }: Props) => {
+  const addSymbol = useWatchlistStore((s) => s.addSymbol);
+  const removeSymbol = useWatchlistStore((s) => s.removeSymbol);
+
+  const [isAddOpen, setAddOpen] = useState(false);
+
+  const coinList = useMemo(
+    () =>
+      symbols
+        .map((symbol) => market.tickerMap.get(symbol))
+        .filter((data): data is CombinedTickers => Boolean(data)),
+    [symbols, market.tickerMap],
+  );
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col rounded-xl overflow-hidden',
+        'border border-border bg-surface',
+        'shadow-sm hover:shadow-md transition-shadow',
+      )}
+    >
+      <div
+        className={cn(
+          'flex items-center justify-between gap-2',
+          'px-3 py-2 border-b border-border',
+        )}
+      >
+        <div className={cn('flex items-center gap-2')}>
+          <span
+            className={cn(
+              'px-2 py-0.5 rounded-md text-xs font-bold',
+              'bg-[#f8b64c]/15 text-[#b9791a] dark:text-[#f8b64c]',
+            )}
+          >
+            {market.label}
+          </span>
+          <span className={cn('text-xs text-fg-muted')}>
+            {symbols.length}종목
+          </span>
+        </div>
+        <Button
+          className={cn(
+            'flex items-center gap-1 px-2 h-7 rounded-md',
+            'text-xs font-medium text-fg-muted',
+            'hover:bg-bg hover:text-fg transition-colors',
+          )}
+          aria-label={`${market.label} 종목 추가`}
+          onClick={() => setAddOpen(true)}
+        >
+          <Icon name="Plus" size={14} />
+          추가
+        </Button>
+      </div>
+
+      {symbols.length === 0 ? (
+        <button
+          type="button"
+          className={cn(
+            'flex flex-col items-center justify-center gap-1.5',
+            'px-4 py-8 text-center w-full',
+            'text-fg-muted hover:bg-bg transition-colors',
+          )}
+          onClick={() => setAddOpen(true)}
+        >
+          <Icon name="Plus" size={18} />
+          <span className={cn('text-sm')}>종목 추가</span>
+        </button>
+      ) : (
+        <CoinTable
+          bare
+          marketType={market.key}
+          coinList={coinList}
+          onRemove={(symbol) => removeSymbol(groupId, market.key, symbol)}
+          emptyMessage="표시할 시세가 없어요"
+        />
+      )}
+
+      <AddCoinModal
+        isOpen={isAddOpen}
+        onClose={() => setAddOpen(false)}
+        groupName={`${groupName} · ${market.label}`}
+        coinData={market.coinData}
+        selectedSymbols={symbols}
+        onToggle={(symbol, checked) =>
+          checked
+            ? addSymbol(groupId, market.key, symbol)
+            : removeSymbol(groupId, market.key, symbol)
+        }
+      />
+    </div>
+  );
+};
+
+export default MarketCard;

--- a/apps/web/src/app/watchlist/components/Page.tsx
+++ b/apps/web/src/app/watchlist/components/Page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useMemo } from 'react';
+import { useMounted } from 'ownui-system';
+import { useCoinList } from '@/hooks';
+import { getLocalStorageData } from '@/lib/storage';
+import { cn } from '@/lib/utils';
+import { CombinedTickers, useCryptoSocketStore } from '@/store/socket';
+import { useWatchlistStore } from '@/store/watchlist';
+import { Coin, TickerType } from '@/types/Coin';
+import GroupCard from './GroupCard';
+
+export type MarketView = {
+  key: TickerType;
+  label: string;
+  tickerMap: Map<string, CombinedTickers>;
+  // The market's full coin universe (for the "add coin" picker).
+  coinData: Coin[];
+};
+
+const toMap = (list: CombinedTickers[]) => {
+  const map = new Map<string, CombinedTickers>();
+  list.forEach((ticker) => map.set(ticker.symbol, ticker));
+  return map;
+};
+
+const WatchlistPage = () => {
+  const mounted = useMounted();
+  const { krwCoinData, btcCoinData, usdtCoinData } = useCoinList();
+
+  const combineTickers = useCryptoSocketStore((s) => s.combineTickers);
+  // Subscribe to the live snapshot so the derived maps recompute on each tick.
+  const tickers = useCryptoSocketStore((s) => s.tickers);
+
+  const groups = useWatchlistStore((s) => s.groups);
+  const seeded = useWatchlistStore((s) => s.seeded);
+  const seedFromLegacy = useWatchlistStore((s) => s.seedFromLegacy);
+
+  // One-time, non-destructive migration of the legacy per-market favorites
+  // into the default group, keeping each market's list separate.
+  useEffect(() => {
+    if (seeded) return;
+    const krwFav: string[] = getLocalStorageData('krwfav') ?? [];
+    const btcFav: string[] = getLocalStorageData('btcfav') ?? [];
+    seedFromLegacy({ KRW: krwFav, BTC: btcFav });
+  }, [seeded, seedFromLegacy]);
+
+  const markets = useMemo<MarketView[]>(
+    () => [
+      {
+        key: 'KRW',
+        label: 'KRW',
+        tickerMap: toMap(combineTickers(krwCoinData, 'KRW')),
+        coinData: krwCoinData,
+      },
+      {
+        key: 'BTC',
+        label: 'BTC',
+        tickerMap: toMap(combineTickers(btcCoinData, 'BTC')),
+        coinData: btcCoinData,
+      },
+      {
+        key: 'USDT',
+        label: 'USDT',
+        tickerMap: toMap(combineTickers(usdtCoinData, 'USDT')),
+        coinData: usdtCoinData,
+      },
+    ],
+    // `tickers` drives the live update; combineTickers reads the latest snapshot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [combineTickers, krwCoinData, btcCoinData, usdtCoinData, tickers],
+  );
+
+  return (
+    <section className="pb-8 max-xl:pb-[5.25rem]">
+      <div className={cn('w-full', 'max-md:mt-1')}>
+        <div className={cn('mt-4 mb-4')}>
+          <h1 className={cn('m-0 text-2xl font-bold max-md:text-xl')}>
+            관심종목
+          </h1>
+          <p className={cn('m-0 mt-1 text-sm text-fg-muted')}>
+            마켓(KRW·BTC·USDT)별 시세를 한 화면에서 확인하세요.
+          </p>
+        </div>
+
+        {!mounted ? (
+          <div className={cn('py-16 text-center text-sm text-fg-muted')}>
+            불러오는 중...
+          </div>
+        ) : (
+          <div className={cn('flex flex-col gap-6')}>
+            {groups.map((group) => (
+              <GroupCard key={group.id} group={group} markets={markets} />
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default WatchlistPage;

--- a/apps/web/src/app/watchlist/components/Page.tsx
+++ b/apps/web/src/app/watchlist/components/Page.tsx
@@ -45,30 +45,51 @@ const WatchlistPage = () => {
     seedFromLegacy({ KRW: krwFav, BTC: btcFav });
   }, [seeded, seedFromLegacy]);
 
+  // Only the coins actually watched (across all groups) per market — combining
+  // tickers over the full universe every socket tick would be wasteful.
+  const watchedByMarket = useMemo(() => {
+    const pick = (market: TickerType, universe: Coin[]) => {
+      const watched = new Set(groups.flatMap((g) => g.markets?.[market] || []));
+      return (universe || []).filter((coin) => watched.has(coin.name));
+    };
+    return {
+      KRW: pick('KRW', krwCoinData),
+      BTC: pick('BTC', btcCoinData),
+      USDT: pick('USDT', usdtCoinData),
+    };
+  }, [groups, krwCoinData, btcCoinData, usdtCoinData]);
+
   const markets = useMemo<MarketView[]>(
     () => [
       {
         key: 'KRW',
         label: 'KRW',
-        tickerMap: toMap(combineTickers(krwCoinData, 'KRW')),
-        coinData: krwCoinData,
+        tickerMap: toMap(combineTickers(watchedByMarket.KRW, 'KRW')),
+        coinData: krwCoinData || [],
       },
       {
         key: 'BTC',
         label: 'BTC',
-        tickerMap: toMap(combineTickers(btcCoinData, 'BTC')),
-        coinData: btcCoinData,
+        tickerMap: toMap(combineTickers(watchedByMarket.BTC, 'BTC')),
+        coinData: btcCoinData || [],
       },
       {
         key: 'USDT',
         label: 'USDT',
-        tickerMap: toMap(combineTickers(usdtCoinData, 'USDT')),
-        coinData: usdtCoinData,
+        tickerMap: toMap(combineTickers(watchedByMarket.USDT, 'USDT')),
+        coinData: usdtCoinData || [],
       },
     ],
     // `tickers` drives the live update; combineTickers reads the latest snapshot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [combineTickers, krwCoinData, btcCoinData, usdtCoinData, tickers],
+    [
+      combineTickers,
+      krwCoinData,
+      btcCoinData,
+      usdtCoinData,
+      watchedByMarket,
+      tickers,
+    ],
   );
 
   return (

--- a/apps/web/src/app/watchlist/page.tsx
+++ b/apps/web/src/app/watchlist/page.tsx
@@ -1,0 +1,5 @@
+import WatchlistPage from './components/Page';
+
+export default async function Watchlist() {
+  return <WatchlistPage />;
+}

--- a/apps/web/src/components/shell/Layout/Header.tsx
+++ b/apps/web/src/components/shell/Layout/Header.tsx
@@ -40,7 +40,12 @@ const Header = () => {
             </div>
           </Link>
         </div>
-        <div className={cn('flex items-center gap-2')}>
+        <div className={cn('flex items-center gap-3')}>
+          <Link href="/watchlist">
+            <Text fontSize="14px" color={palette.white}>
+              관심종목
+            </Text>
+          </Link>
           <Link href="/trend">
             <Text fontSize="14px" color={palette.white}>
               코인동향

--- a/apps/web/src/components/ui/Table/Header.tsx
+++ b/apps/web/src/components/ui/Table/Header.tsx
@@ -12,7 +12,8 @@ const Header = ({ name, width, right, onClick }: Props) => {
   return (
     <div
       className={cn(
-        'flex items-center cursor-pointer',
+        'flex items-center',
+        onClick && 'cursor-pointer',
         'px-2 py-3 font-normal w-[var(--width)]',
         'max-lg:text-[14px] max-md:text-[12px] max-sm:text-[10px]',
       )}

--- a/apps/web/src/components/ui/Table/index.tsx
+++ b/apps/web/src/components/ui/Table/index.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils';
 import Cell from './Cell';
 import Header from './Header';
 import Row from './Row';
@@ -6,11 +7,19 @@ import Skeleton from './Skeleton';
 type Props = {
   header: JSX.Element | React.ReactElement;
   body: JSX.Element | React.ReactElement;
+  // Drop the outer border/background/rounding so the table can sit inside an
+  // already-bordered container (e.g. the watchlist market cards).
+  bare?: boolean;
 };
 
-const Table = ({ header, body }: Props) => {
+const Table = ({ header, body, bare = false }: Props) => {
   return (
-    <div className="w-full rounded-lg border border-border bg-surface">
+    <div
+      className={cn(
+        'w-full',
+        bare ? 'text-[13px]' : 'rounded-lg border border-border bg-surface',
+      )}
+    >
       <div className="flex items-center border-b border-b-border">{header}</div>
       <div>{body}</div>
     </div>

--- a/apps/web/src/store/watchlist.ts
+++ b/apps/web/src/store/watchlist.ts
@@ -1,0 +1,152 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { generateUid, removeDuplicate } from '@/lib/utils';
+import type { TickerType } from '@/types/Coin';
+
+// zustand
+
+export const MARKETS: TickerType[] = ['KRW', 'BTC', 'USDT'];
+
+// Each market keeps its own watch list so KRW/BTC/USDT are managed separately.
+export type MarketSymbols = Record<TickerType, string[]>;
+
+export type WatchGroup = {
+  id: string;
+  name: string;
+  markets: MarketSymbols;
+};
+
+export const DEFAULT_GROUP_ID = 'default';
+
+const emptyMarkets = (): MarketSymbols => ({ KRW: [], BTC: [], USDT: [] });
+
+type State = {
+  groups: WatchGroup[];
+  // Whether the one-time migration from the legacy krwfav/btcfav favorites has
+  // already run. Kept in persisted state so the seed happens exactly once.
+  seeded: boolean;
+};
+
+type Action = {
+  createGroup: (name: string) => void;
+  renameGroup: (id: string, name: string) => void;
+  deleteGroup: (id: string) => void;
+  addSymbol: (groupId: string, market: TickerType, symbol: string) => void;
+  removeSymbol: (groupId: string, market: TickerType, symbol: string) => void;
+  seedFromLegacy: (legacy: Partial<MarketSymbols>) => void;
+};
+
+const createDefaultGroup = (): WatchGroup => ({
+  id: DEFAULT_GROUP_ID,
+  name: '내 관심종목',
+  markets: emptyMarkets(),
+});
+
+const mapGroup = (
+  groups: WatchGroup[],
+  id: string,
+  fn: (group: WatchGroup) => WatchGroup,
+) => groups.map((group) => (group.id === id ? fn(group) : group));
+
+export const useWatchlistStore = create<State & Action>()(
+  persist(
+    (set) => ({
+      groups: [createDefaultGroup()],
+      seeded: false,
+      createGroup: (name: string) => {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        set((state) => ({
+          groups: [
+            ...state.groups,
+            { id: generateUid(), name: trimmed, markets: emptyMarkets() },
+          ],
+        }));
+      },
+      renameGroup: (id: string, name: string) => {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        set((state) => ({
+          groups: mapGroup(state.groups, id, (group) => ({
+            ...group,
+            name: trimmed,
+          })),
+        }));
+      },
+      deleteGroup: (id: string) => {
+        set((state) => {
+          // Keep at least one group so the page always has something to render.
+          if (state.groups.length <= 1) return state;
+          return { groups: state.groups.filter((group) => group.id !== id) };
+        });
+      },
+      addSymbol: (groupId: string, market: TickerType, symbol: string) => {
+        set((state) => ({
+          groups: mapGroup(state.groups, groupId, (group) => ({
+            ...group,
+            markets: {
+              ...group.markets,
+              [market]: removeDuplicate([...group.markets[market], symbol]),
+            },
+          })),
+        }));
+      },
+      removeSymbol: (groupId: string, market: TickerType, symbol: string) => {
+        set((state) => ({
+          groups: mapGroup(state.groups, groupId, (group) => ({
+            ...group,
+            markets: {
+              ...group.markets,
+              [market]: group.markets[market].filter((s) => s !== symbol),
+            },
+          })),
+        }));
+      },
+      seedFromLegacy: (legacy: Partial<MarketSymbols>) => {
+        set((state) => {
+          if (state.seeded) return state;
+          return {
+            seeded: true,
+            groups: mapGroup(state.groups, DEFAULT_GROUP_ID, (group) => ({
+              ...group,
+              markets: {
+                KRW: removeDuplicate([
+                  ...group.markets.KRW,
+                  ...(legacy.KRW ?? []),
+                ]),
+                BTC: removeDuplicate([
+                  ...group.markets.BTC,
+                  ...(legacy.BTC ?? []),
+                ]),
+                USDT: removeDuplicate([
+                  ...group.markets.USDT,
+                  ...(legacy.USDT ?? []),
+                ]),
+              },
+            })),
+          };
+        });
+      },
+    }),
+    {
+      name: 'watchlist',
+      version: 1,
+      // v0 stored a single shared `symbols` list per group; move it under KRW.
+      migrate: (persisted: any, version: number) => {
+        if (version < 1 && persisted?.groups) {
+          persisted.groups = persisted.groups.map((group: any) => ({
+            id: group.id,
+            name: group.name,
+            markets: {
+              KRW: group.symbols ?? [],
+              BTC: [],
+              USDT: [],
+            },
+          }));
+        }
+        return persisted as State;
+      },
+      partialize: (state) => ({ groups: state.groups, seeded: state.seeded }),
+    },
+  ),
+);

--- a/apps/web/src/store/watchlist.ts
+++ b/apps/web/src/store/watchlist.ts
@@ -86,7 +86,10 @@ export const useWatchlistStore = create<State & Action>()(
             ...group,
             markets: {
               ...group.markets,
-              [market]: removeDuplicate([...group.markets[market], symbol]),
+              [market]: removeDuplicate([
+                ...(group.markets[market] || []),
+                symbol,
+              ]),
             },
           })),
         }));
@@ -97,7 +100,9 @@ export const useWatchlistStore = create<State & Action>()(
             ...group,
             markets: {
               ...group.markets,
-              [market]: group.markets[market].filter((s) => s !== symbol),
+              [market]: (group.markets[market] || []).filter(
+                (s) => s !== symbol,
+              ),
             },
           })),
         }));
@@ -111,15 +116,15 @@ export const useWatchlistStore = create<State & Action>()(
               ...group,
               markets: {
                 KRW: removeDuplicate([
-                  ...group.markets.KRW,
+                  ...(group.markets.KRW || []),
                   ...(legacy.KRW ?? []),
                 ]),
                 BTC: removeDuplicate([
-                  ...group.markets.BTC,
+                  ...(group.markets.BTC || []),
                   ...(legacy.BTC ?? []),
                 ]),
                 USDT: removeDuplicate([
-                  ...group.markets.USDT,
+                  ...(group.markets.USDT || []),
                   ...(legacy.USDT ?? []),
                 ]),
               },


### PR DESCRIPTION
# 요약

- 관심 코인만 모아 보는 `/watchlist` 페이지를 추가하고, KRW·BTC·USDT 마켓별로 관심목록을 각각 독립 관리할 수 있게 했습니다.

## 주요 작업:

- `/watchlist` 라우트 추가 — 관심코인을 **마켓별(KRW/BTC/USDT) 카드**로 한 화면에 표시(탭 없음), 각 카드가 자기 목록만 추가/삭제하며 마켓별 코인 피커 제공
- 관심목록 상태 스토어 신설(`store/watchlist.ts`) — `zustand` `persist`(version 1), 그룹의 마켓별 심볼 목록(`markets: { KRW, BTC, USDT }`) 보관, 최초 진입 시 기존 `krwfav`/`btcfav` 즐겨찾기를 기본 그룹으로 비파괴 마이그레이션
- 실시간 시세는 기존 `combineTickers`(SharedWorker 스냅샷) 파이프라인을 그대로 재사용 — 마켓별 3개 티커 맵을 구독 기반으로 산출
- 기존 `CoinTable`을 옵션 prop(`onRemove`/`marketType`/`bare`)으로 재사용 — 메인 페이지 동작은 불변
- 헤더 내비게이션에 `관심종목` 링크 추가

## 기타 작업:

- 공용 `Table`에 `bare` 변형(외곽선/배경 제거) 추가, 정렬 헤더의 `cursor-pointer`를 `onClick` 있을 때만 적용
- 워치리스트 카드 UI 정리 — 마켓 배지, 내용 높이에 맞는 카드(그리드 `items-start`), 텍스트 크기 축소, 정렬 아이콘 제거, 삭제(X) 버튼 hover 배경 제거
- 종목 추가 모달 높이 제한(목록 내부 스크롤)

## 고민사항 및 추후 고려사항:

- 그룹 생성/이름변경/삭제 UI는 이번 범위에서 제거해 사실상 단일 관심목록(마켓 3분할)으로 동작합니다. 스토어의 그룹 구조와 `GroupFormModal`은 남겨둬 그룹 기능을 되살리기 쉽게 했습니다.
- 메인 페이지 별표 즐겨찾기(`krwfav`/`btcfav`)와 워치리스트의 통합 여부는 후속 과제로 남겼습니다(현재는 최초 1회 시드만).
- 로컬 dev 환경에선 BTC 마켓 시세 피드가 대부분 들어오지 않아 BTC 카드가 비어 보일 수 있으나, 정상 피드 환경에선 KRW처럼 채워집니다.
- 페이지 폭은 전역 레이아웃 상한(`max-w-[1410px]`)까지 사용합니다. 그 이상 광폭이 필요하면 전역 셸 조정이 필요합니다.