### PR TITLE
fix(web): guard FearGreed against render errors with ErrorBoundary

### DIFF
--- a/apps/web/src/components/shell/FearGreed/FearGreed.server.tsx
+++ b/apps/web/src/components/shell/FearGreed/FearGreed.server.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import Skeleton from '@/components/ui/Skeleton';
 import { cn } from '@/lib/utils';
 import FearGreed from './index';
@@ -14,11 +15,13 @@ export default function FearGreedServer() {
       )}
     >
       <div className="inline-flex">
-        <Suspense
-          fallback={<Skeleton width="100%" height={20} borderRadius="4px" />}
-        >
-          <FearGreed />
-        </Suspense>
+        <ErrorBoundary fallback={null}>
+          <Suspense
+            fallback={<Skeleton width="100%" height={20} borderRadius="4px" />}
+          >
+            <FearGreed />
+          </Suspense>
+        </ErrorBoundary>
       </div>
     </section>
   );

--- a/apps/web/src/components/shell/FearGreed/FearGreed.server.tsx
+++ b/apps/web/src/components/shell/FearGreed/FearGreed.server.tsx
@@ -6,23 +6,23 @@ import FearGreed from './index';
 
 export default function FearGreedServer() {
   return (
-    <section
-      className={cn(
-        'flex justify-between items-center',
-        'p-3 mt-2 bg-surface border border-border font-semibold',
-        'max-md:p-2 max-md:mt-0 max-md:text-sm',
-        'max-sm:text-[11px]',
-      )}
-    >
-      <div className="inline-flex">
-        <ErrorBoundary fallback={null}>
+    <ErrorBoundary fallback={null}>
+      <section
+        className={cn(
+          'flex justify-between items-center',
+          'p-3 mt-2 bg-surface border border-border font-semibold',
+          'max-md:p-2 max-md:mt-0 max-md:text-sm',
+          'max-sm:text-[11px]',
+        )}
+      >
+        <div className="inline-flex">
           <Suspense
             fallback={<Skeleton width="100%" height={20} borderRadius="4px" />}
           >
             <FearGreed />
           </Suspense>
-        </ErrorBoundary>
-      </div>
-    </section>
+        </div>
+      </section>
+    </ErrorBoundary>
   );
 }


### PR DESCRIPTION
# 요약

- FearGreed 위젯의 데이터 페칭/렌더링 실패가 상위 레이아웃(shell) 전체를 크래시시키던 문제를 방지합니다.

## 주요 작업:

- `FearGreed.server.tsx`에서 `FearGreed`를 `react-error-boundary`의 `ErrorBoundary`로 감싸 렌더링 에러를 격리
- 에러 발생 시 `fallback={null}`로 아무것도 렌더하지 않도록 처리하여 나머지 UI는 정상 동작 유지
- 로딩 상태의 `Suspense` 스켈레톤은 그대로 유지

## 기타 작업:

- 없음

## 고민사항 및 추후 고려사항:

- 현재는 에러 시 조용히 숨김(`fallback={null}`) 처리입니다. 필요 시 에러 상태를 나타내는 UI나 로깅/모니터링(예: Sentry) 연동을 추후 고려할 수 있습니다.