### PR TITLE
refactor(web): reorder watchlist market cards to KRW/USDT/BTC

### DIFF
--- a/apps/web/src/app/watchlist/components/Page.tsx
+++ b/apps/web/src/app/watchlist/components/Page.tsx
@@ -68,16 +68,16 @@ const WatchlistPage = () => {
         coinData: krwCoinData || [],
       },
       {
-        key: 'BTC',
-        label: 'BTC',
-        tickerMap: toMap(combineTickers(watchedByMarket.BTC, 'BTC')),
-        coinData: btcCoinData || [],
-      },
-      {
         key: 'USDT',
         label: 'USDT',
         tickerMap: toMap(combineTickers(watchedByMarket.USDT, 'USDT')),
         coinData: usdtCoinData || [],
+      },
+      {
+        key: 'BTC',
+        label: 'BTC',
+        tickerMap: toMap(combineTickers(watchedByMarket.BTC, 'BTC')),
+        coinData: btcCoinData || [],
       },
     ],
     // `tickers` drives the live update; combineTickers reads the latest snapshot.
@@ -100,7 +100,7 @@ const WatchlistPage = () => {
             관심종목
           </h1>
           <p className={cn('m-0 mt-1 text-sm text-fg-muted')}>
-            마켓(KRW·BTC·USDT)별 시세를 한 화면에서 확인하세요.
+            마켓(KRW·USDT·BTC)별 시세를 한 화면에서 확인하세요.
           </p>
         </div>
 


### PR DESCRIPTION
# 요약

- 관심종목 페이지의 마켓 카드 배치 순서를 KRW → USDT → BTC로 변경합니다.

## 주요 작업:

- `Page.tsx`의 `markets` 배열에서 BTC와 USDT 항목 순서를 교체하여 카드가 KRW → USDT → BTC 순으로 렌더링되도록 변경
- 헤더 안내 문구를 `마켓(KRW·BTC·USDT)` → `마켓(KRW·USDT·BTC)`로 정렬

## 기타 작업:

- 없음

## 고민사항 및 추후 고려사항:

- 카드 순서는 `GroupCard`가 `markets` 배열 순서대로 렌더링하므로 배열만 변경하면 됩니다. store의 마켓 접근은 key 기반이라 순서 변경 영향 없음.
- `store/watchlist.ts`의 `MARKETS` 상수는 현재 어디서도 사용되지 않아(선언만 존재) 이번 변경 대상에서 제외했습니다.