### PR TITLE
refactor(web): use named function expressions for useEffect callbacks

### DIFF
--- a/apps/web/src/app/trading-view/components/chart.tsx
+++ b/apps/web/src/app/trading-view/components/chart.tsx
@@ -74,23 +74,29 @@ export default function Chart({ code, type }: ChartProps) {
     });
   };
 
-  useEffect(() => {
-    const checkCodeValidation = async () => {
-      const response = await getCoins(type === 'BTC' ? 'BTC' : 'KRW');
-      const data = response.find((item: Coin) => item.name === code);
+  useEffect(
+    function redirectOnUnknownCode() {
+      const checkCodeValidation = async () => {
+        const response = await getCoins(type === 'BTC' ? 'BTC' : 'KRW');
+        const data = response.find((item: Coin) => item.name === code);
 
-      if (!data) {
-        navigate.replace('/');
-        return;
-      }
-    };
+        if (!data) {
+          navigate.replace('/');
+          return;
+        }
+      };
 
-    checkCodeValidation();
-  }, [code, navigate, type]);
+      checkCodeValidation();
+    },
+    [code, navigate, type],
+  );
 
-  useEffect(() => {
-    setActiveTimeTab(DEFAULT_TAB);
-  }, [code]);
+  useEffect(
+    function resetTimeTabOnCodeChange() {
+      setActiveTimeTab(DEFAULT_TAB);
+    },
+    [code],
+  );
 
   return (
     <Flex

--- a/apps/web/src/app/watchlist/components/GroupFormModal/index.tsx
+++ b/apps/web/src/app/watchlist/components/GroupFormModal/index.tsx
@@ -25,9 +25,12 @@ const GroupFormModal = ({
 }: Props) => {
   const [name, setName] = useState(initialName);
 
-  useEffect(() => {
-    if (isOpen) setName(initialName);
-  }, [isOpen, initialName]);
+  useEffect(
+    function syncNameOnOpen() {
+      if (isOpen) setName(initialName);
+    },
+    [isOpen, initialName],
+  );
 
   const handleSubmit = () => {
     const trimmed = name.trim();

--- a/apps/web/src/app/watchlist/components/Page.tsx
+++ b/apps/web/src/app/watchlist/components/Page.tsx
@@ -38,12 +38,15 @@ const WatchlistPage = () => {
 
   // One-time, non-destructive migration of the legacy per-market favorites
   // into the default group, keeping each market's list separate.
-  useEffect(() => {
-    if (seeded) return;
-    const krwFav: string[] = getLocalStorageData('krwfav') ?? [];
-    const btcFav: string[] = getLocalStorageData('btcfav') ?? [];
-    seedFromLegacy({ KRW: krwFav, BTC: btcFav });
-  }, [seeded, seedFromLegacy]);
+  useEffect(
+    function seedGroupsFromLegacyFavorites() {
+      if (seeded) return;
+      const krwFav: string[] = getLocalStorageData('krwfav') ?? [];
+      const btcFav: string[] = getLocalStorageData('btcfav') ?? [];
+      seedFromLegacy({ KRW: krwFav, BTC: btcFav });
+    },
+    [seeded, seedFromLegacy],
+  );
 
   // Only the coins actually watched (across all groups) per market — combining
   // tickers over the full universe every socket tick would be wasteful.

--- a/apps/web/src/components/shell/NavigationEvents.tsx
+++ b/apps/web/src/components/shell/NavigationEvents.tsx
@@ -8,21 +8,24 @@ export function NavigationEvents() {
   const searchParams = useSearchParams();
   const { updateType } = useCoinStore();
 
-  useEffect(() => {
-    const type = searchParams?.get('type');
+  useEffect(
+    function syncTypeFromSearchParams() {
+      const type = searchParams?.get('type');
 
-    if (type === 'BTC') {
-      updateType('BTC');
-    }
+      if (type === 'BTC') {
+        updateType('BTC');
+      }
 
-    if (type === 'USDT') {
-      updateType('USDT');
-    }
+      if (type === 'USDT') {
+        updateType('USDT');
+      }
 
-    if (!type || type === 'KRW') {
-      updateType('KRW');
-    }
-  }, [searchParams, updateType]);
+      if (!type || type === 'KRW') {
+        updateType('KRW');
+      }
+    },
+    [searchParams, updateType],
+  );
 
   return null;
 }

--- a/apps/web/src/components/shell/Providers/SharedWorkerProvider.tsx
+++ b/apps/web/src/components/shell/Providers/SharedWorkerProvider.tsx
@@ -23,37 +23,40 @@ export default function SharedWorkerProvider({ children }: PropsWithChildren) {
     refetchInterval: 1000,
   });
 
-  useEffect(() => {
-    if (!isMounted) return;
+  useEffect(
+    function connectTickerSource() {
+      if (!isMounted) return;
 
-    // Progressive source: SharedWorker → Dedicated Worker → main thread.
-    // Unsupported browsers silently fall back instead of crashing the error boundary.
-    const source = createTickerSource(({ upbit, binance }) => {
-      setSocketState({
-        tickers: {
-          upbit: upbit.data,
-          binance: binance.data,
-        },
-        btcKrw: {
-          upbit: upbit.btcKrw,
-          binance: binance.btcKrw,
-        },
+      // Progressive source: SharedWorker → Dedicated Worker → main thread.
+      // Unsupported browsers silently fall back instead of crashing the error boundary.
+      const source = createTickerSource(({ upbit, binance }) => {
+        setSocketState({
+          tickers: {
+            upbit: upbit.data,
+            binance: binance.data,
+          },
+          btcKrw: {
+            upbit: upbit.btcKrw,
+            binance: binance.btcKrw,
+          },
+        });
       });
-    });
 
-    sourceRef.current = source;
-    setReady(true);
+      sourceRef.current = source;
+      setReady(true);
 
-    const handleUnload = () => source.disconnect();
-    window.addEventListener('unload', handleUnload);
+      const handleUnload = () => source.disconnect();
+      window.addEventListener('unload', handleUnload);
 
-    return () => {
-      window.removeEventListener('unload', handleUnload);
-      source.disconnect();
-      sourceRef.current = null;
-      setReady(false);
-    };
-  }, [isMounted, setSocketState]);
+      return () => {
+        window.removeEventListener('unload', handleUnload);
+        source.disconnect();
+        sourceRef.current = null;
+        setReady(false);
+      };
+    },
+    [isMounted, setSocketState],
+  );
 
   return <>{children}</>;
 }

--- a/apps/web/src/components/shell/ThemeToggle.tsx
+++ b/apps/web/src/components/shell/ThemeToggle.tsx
@@ -45,7 +45,7 @@ const ThemeToggle = () => {
   // The store initializes from the DOM on the client, but SSR/first client
   // render is always 'light'; render a same-size placeholder until mounted to
   // avoid a hydration mismatch and an icon flip / layout shift.
-  useEffect(() => {
+  useEffect(function markMounted() {
     setMounted(true);
   }, []);
 

--- a/apps/web/src/components/ui/Icon.tsx
+++ b/apps/web/src/components/ui/Icon.tsx
@@ -12,13 +12,16 @@ const Icon = ({ name, width, height, borderRadius = '8px' }: Props) => {
   const ref = useRef<any | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    setIsLoading(true);
-    import(`../../public/assets/icons/${name}.svg`).then((mod) => {
-      ref.current = mod.default;
-      setIsLoading(false);
-    });
-  }, [name]);
+  useEffect(
+    function loadIconModule() {
+      setIsLoading(true);
+      import(`../../public/assets/icons/${name}.svg`).then((mod) => {
+        ref.current = mod.default;
+        setIsLoading(false);
+      });
+    },
+    [name],
+  );
 
   if (ref.current) {
     const { current: SVG } = ref;

--- a/apps/web/src/hooks/common/useMount.ts
+++ b/apps/web/src/hooks/common/useMount.ts
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 const useMount = () => {
   const [isMounted, setIsMounted] = useState(false);
 
-  useEffect(() => {
+  useEffect(function markMounted() {
     setIsMounted(true);
   }, []);
 

--- a/apps/web/src/hooks/common/useMountTransition.ts
+++ b/apps/web/src/hooks/common/useMountTransition.ts
@@ -5,19 +5,22 @@ import { useEffect, useState } from 'react';
 const useMountTransition = (isMounted: boolean, unmountDelay: number) => {
   const [isTransitioning, setIsTransitioning] = useState(false);
 
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
+  useEffect(
+    function runMountTransition() {
+      let timeoutId: NodeJS.Timeout;
 
-    if (isMounted && !isTransitioning) {
-      setIsTransitioning(true);
-    } else if (!isMounted && isTransitioning) {
-      timeoutId = setTimeout(() => setIsTransitioning(false), unmountDelay);
-    }
+      if (isMounted && !isTransitioning) {
+        setIsTransitioning(true);
+      } else if (!isMounted && isTransitioning) {
+        timeoutId = setTimeout(() => setIsTransitioning(false), unmountDelay);
+      }
 
-    return () => {
-      clearTimeout(timeoutId);
-    };
-  }, [isMounted, unmountDelay, isTransitioning]);
+      return () => {
+        clearTimeout(timeoutId);
+      };
+    },
+    [isMounted, unmountDelay, isTransitioning],
+  );
 
   return isTransitioning;
 };

--- a/apps/web/src/hooks/queries/useBinanceCandles.ts
+++ b/apps/web/src/hooks/queries/useBinanceCandles.ts
@@ -58,11 +58,14 @@ const useBinanceCandles = ({
     refetchOnWindowFocus: false,
   });
 
-  useEffect(() => {
-    if (!data || !enabled) return;
+  useEffect(
+    function notifyCandlesLoaded() {
+      if (!data || !enabled) return;
 
-    onSuccess?.(data);
-  }, [data, enabled, onSuccess]);
+      onSuccess?.(data);
+    },
+    [data, enabled, onSuccess],
+  );
 
   return {
     data,

--- a/apps/web/src/hooks/queries/useInitCoinList.ts
+++ b/apps/web/src/hooks/queries/useInitCoinList.ts
@@ -11,23 +11,26 @@ type UseInitCointListProps = {
 const useInitCoinList = ({ initialData }: UseInitCointListProps) => {
   const { setList, isLoading } = useCoinStore();
 
-  useEffect(() => {
-    if (
-      initialData.krw.length === 0 ||
-      initialData.btc.length === 0 ||
-      !isLoading
-    ) {
-      return;
-    }
+  useEffect(
+    function hydrateCoinStore() {
+      if (
+        initialData.krw.length === 0 ||
+        initialData.btc.length === 0 ||
+        !isLoading
+      ) {
+        return;
+      }
 
-    const { krw, btc, usdt } = initialData;
+      const { krw, btc, usdt } = initialData;
 
-    setList({
-      krw,
-      btc,
-      usdt,
-    });
-  }, [initialData, isLoading, setList]);
+      setList({
+        krw,
+        btc,
+        usdt,
+      });
+    },
+    [initialData, isLoading, setList],
+  );
 };
 
 export default useInitCoinList;

--- a/apps/web/src/hooks/queries/useUpbitCandles.ts
+++ b/apps/web/src/hooks/queries/useUpbitCandles.ts
@@ -79,11 +79,14 @@ const useUpbitCandles = ({
     },
   });
 
-  useEffect(() => {
-    if (!data || !enabled || !isFetched) return;
+  useEffect(
+    function notifyCandlesLoaded() {
+      if (!data || !enabled || !isFetched) return;
 
-    onSuccess?.(data);
-  }, [enabled, data, onSuccess, isFetched]);
+      onSuccess?.(data);
+    },
+    [enabled, data, onSuccess, isFetched],
+  );
 
   return { data, isFetched, ...rest };
 };

--- a/apps/web/src/hooks/trading-view/useUpbitDataFeed.ts
+++ b/apps/web/src/hooks/trading-view/useUpbitDataFeed.ts
@@ -163,106 +163,121 @@ const useUpbitDataFeed = ({
     }, 1000);
   }, [fetchPreviousCandles]);
 
-  useEffect(() => {
-    if (!containerRef.current) return;
+  useEffect(
+    function createChartInstance() {
+      if (!containerRef.current) return;
 
-    // ✅ 차트 생성
-    const chart = createChart(containerRef.current, {
-      layout: {
-        background: { type: ColorType.Solid, color: colors.backgroundColor },
-        textColor: colors.textColor,
-      },
+      // ✅ 차트 생성
+      const chart = createChart(containerRef.current, {
+        layout: {
+          background: { type: ColorType.Solid, color: colors.backgroundColor },
+          textColor: colors.textColor,
+        },
 
-      width: containerRef.current.clientWidth,
-      height: 300,
-    });
-    chartRef.current = chart;
+        width: containerRef.current.clientWidth,
+        height: 300,
+      });
+      chartRef.current = chart;
 
-    // ✅ 리사이즈 대응
-    const handleResize = () => {
-      if (containerRef.current) {
-        chart.applyOptions({ width: containerRef.current.clientWidth });
-      }
-    };
-    window.addEventListener('resize', handleResize);
+      // ✅ 리사이즈 대응
+      const handleResize = () => {
+        if (containerRef.current) {
+          chart.applyOptions({ width: containerRef.current.clientWidth });
+        }
+      };
+      window.addEventListener('resize', handleResize);
 
-    return () => {
-      chart.remove();
-      window.removeEventListener('resize', handleResize);
-      chartRef.current = null;
-      seriesRef.current = null;
-    };
+      return () => {
+        chart.remove();
+        window.removeEventListener('resize', handleResize);
+        chartRef.current = null;
+        seriesRef.current = null;
+      };
+    },
     // colors intentionally omitted: theme changes are applied via applyOptions
     // below so the chart is not recreated (avoids flicker / losing zoom state).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [containerRef]);
+    [containerRef],
+  );
 
   // ✅ 테마 변경 시 차트를 재생성하지 않고 색상 옵션만 갱신
-  useEffect(() => {
-    chartRef.current?.applyOptions({
-      layout: {
-        background: { type: ColorType.Solid, color: colors.backgroundColor },
-        textColor: colors.textColor,
-      },
-    });
-  }, [colors]);
+  useEffect(
+    function applyThemeColors() {
+      chartRef.current?.applyOptions({
+        layout: {
+          background: { type: ColorType.Solid, color: colors.backgroundColor },
+          textColor: colors.textColor,
+        },
+      });
+    },
+    [colors],
+  );
 
   // ✅ 단위가 바뀌었을 때 데이터 교체
-  useEffect(() => {
-    if (!chartRef.current) return;
+  useEffect(
+    function replaceCandleSeries() {
+      if (!chartRef.current) return;
 
-    // 기존 시리즈 제거
-    if (seriesRef.current) {
-      chartRef.current.removeSeries(seriesRef.current);
-      seriesRef.current = null;
-    }
-
-    // 새 시리즈 생성
-    const newSeries = chartRef.current.addSeries(CandlestickSeries, {
-      upColor: palette.red,
-      downColor: palette.blue,
-      wickUpColor: palette.red,
-      wickDownColor: palette.blue,
-      borderVisible: false,
-      priceFormat: {
-        type: 'price',
-        precision: type === 'BTC' ? 10 : 2, // 보여줄 소수점 자릿수
-        minMove: type === 'BTC' ? 0.0000000001 : 0.001, // 최소 단위
-      },
-    });
-    newSeries.setData(seriesData); // 새로운 단위 데이터 반영
-
-    seriesRef.current = newSeries;
-    chartRef.current.timeScale().fitContent();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [unit, code, type, JSON.stringify(seriesData)]);
-
-  useEffect(() => {
-    if (!wsData || wsData?.open === 0) return;
-
-    seriesRef.current?.update(wsData);
-  }, [wsData]);
-
-  useEffect(() => {
-    if (!chartRef.current) return;
-
-    const handleRangeChange = (range: LogicalRange | null) => {
-      if (!range) return;
-
-      if (range.from < 30) {
-        throttledFetch(); // 👈 여기서 호출
+      // 기존 시리즈 제거
+      if (seriesRef.current) {
+        chartRef.current.removeSeries(seriesRef.current);
+        seriesRef.current = null;
       }
-    };
 
-    const timeScale = chartRef.current.timeScale();
-    timeScale.fitContent();
-    timeScale.subscribeVisibleLogicalRangeChange(handleRangeChange);
+      // 새 시리즈 생성
+      const newSeries = chartRef.current.addSeries(CandlestickSeries, {
+        upColor: palette.red,
+        downColor: palette.blue,
+        wickUpColor: palette.red,
+        wickDownColor: palette.blue,
+        borderVisible: false,
+        priceFormat: {
+          type: 'price',
+          precision: type === 'BTC' ? 10 : 2, // 보여줄 소수점 자릿수
+          minMove: type === 'BTC' ? 0.0000000001 : 0.001, // 최소 단위
+        },
+      });
+      newSeries.setData(seriesData); // 새로운 단위 데이터 반영
 
-    return () => {
-      timeScale.unsubscribeVisibleLogicalRangeChange(handleRangeChange);
-      throttledFetch.cancel?.();
-    };
-  }, [throttledFetch]);
+      seriesRef.current = newSeries;
+      chartRef.current.timeScale().fitContent();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [unit, code, type, JSON.stringify(seriesData)],
+  );
+
+  useEffect(
+    function updateLastCandleFromSocket() {
+      if (!wsData || wsData?.open === 0) return;
+
+      seriesRef.current?.update(wsData);
+    },
+    [wsData],
+  );
+
+  useEffect(
+    function subscribeVisibleRange() {
+      if (!chartRef.current) return;
+
+      const handleRangeChange = (range: LogicalRange | null) => {
+        if (!range) return;
+
+        if (range.from < 30) {
+          throttledFetch(); // 👈 여기서 호출
+        }
+      };
+
+      const timeScale = chartRef.current.timeScale();
+      timeScale.fitContent();
+      timeScale.subscribeVisibleLogicalRangeChange(handleRangeChange);
+
+      return () => {
+        timeScale.unsubscribeVisibleLogicalRangeChange(handleRangeChange);
+        throttledFetch.cancel?.();
+      };
+    },
+    [throttledFetch],
+  );
 
   return {
     chart: chartRef.current,


### PR DESCRIPTION
# 요약

- `useEffect`에 넘기던 익명 화살표 콜백을 전부 기명 함수 표현식으로 변경해, React DevTools와 스택 트레이스에서 어떤 이펙트인지 바로 식별되도록 했습니다.

## 주요 작업:

- `apps/web` 전역 13개 파일의 `useEffect` 콜백 18개를 기명 함수로 변경 (동작 변경 없음)
  - `chart.tsx`: `redirectOnUnknownCode`, `resetTimeTabOnCodeChange`
  - `watchlist/Page.tsx`: `seedGroupsFromLegacyFavorites`
  - `GroupFormModal/index.tsx`: `syncNameOnOpen`
  - `ui/Icon.tsx`: `loadIconModule`
  - `shell/ThemeToggle.tsx`: `markMounted`
  - `shell/NavigationEvents.tsx`: `syncTypeFromSearchParams`
  - `SharedWorkerProvider.tsx`: `connectTickerSource`
  - `useUpbitDataFeed.ts`: `createChartInstance`, `applyThemeColors`, `replaceCandleSeries`, `updateLastCandleFromSocket`, `subscribeVisibleRange`
  - `useUpbitCandles.ts` / `useBinanceCandles.ts`: `notifyCandlesLoaded`
  - `useInitCoinList.ts`: `hydrateCoinStore`
  - `useMount.ts`: `markMounted`
  - `useMountTransition.ts`: `runMountTransition`

## 기타 작업:

- `useUpbitDataFeed.ts`의 `eslint-disable-next-line react-hooks/exhaustive-deps` 주석 2개 위치 수정
  - Prettier가 `useEffect(fn, deps)`를 두 인자 멀티라인 형태로 재정렬하면서 주석이 콜백 본문 마지막 줄로 밀려 deps 배열을 더 이상 가리키지 못하게 됨 → deps 배열 바로 앞으로 이동
- Prettier 포맷 적용에 따른 들여쓰기 변경 (diff 대부분이 이 재정렬 때문에 발생)

## 고민사항 및 추후 고려사항:

- **검증**: `pnpm lint` 경고·에러 0건, `tsc --noEmit` 통과, `pnpm test:ci` 4 suites / 21 tests 전부 통과. 순수 리팩터로 런타임 동작 변경은 없습니다.
- **diff 볼륨**: 실제 의미 있는 변경은 각 `useEffect`의 첫 줄뿐이지만, Prettier가 단일 인자 → 두 인자 형태로 재정렬하면서 콜백 본문 전체가 한 단계 더 들여쓰기됩니다. 리뷰 시 `?w=1`(whitespace 무시) 옵션을 쓰시면 편합니다.
- **범위**: 이번 PR은 `useEffect` 콜백 자체만 대상으로 했습니다. 콜백 **내부**의 인라인 익명 함수(`Icon.tsx`의 `.then((mod) => ...)`, `useMountTransition.ts`의 `setTimeout(() => ...)`, `SharedWorkerProvider.tsx`의 `createTickerSource(({ upbit, binance }) => ...)`, 각 cleanup 함수 등)는 의도적으로 그대로 뒀습니다. 필요하다면 후속 PR에서 정리하는 게 좋아 보입니다.
- **`useIsomorphicLayoutEffect.ts`**: `useLayoutEffect`/`useEffect`를 re-export 하는 alias라 대상 콜백이 없어 변경하지 않았습니다.
- **네이밍 컨벤션**: "이펙트가 무엇을 하는지"를 동사구로 표현하는 방식(`syncTypeFromSearchParams`, `connectTickerSource`)으로 통일했습니다. 다른 컨벤션(예: `handle*` 접두사)을 선호하시면 알려주세요.